### PR TITLE
Parameterize Operate Elasticsearch global full URL

### DIFF
--- a/charts/zeebe-operate-helm/templates/configmap.yaml
+++ b/charts/zeebe-operate-helm/templates/configmap.yaml
@@ -14,6 +14,10 @@ data:
         host: {{ .Values.global.elasticsearch.host }}
         # Transport port
         port: {{ .Values.global.elasticsearch.port }}
+        {{- if .Values.global.elasticsearch.url }}
+        # Elasticsearch full url
+        url: {{ .Values.global.elasticsearch.url }}
+        {{- end }}
       # Zeebe instance
       zeebe:
         # Broker contact point
@@ -28,6 +32,10 @@ data:
         port: {{ .Values.global.elasticsearch.port }}
         # Index prefix, configured in Zeebe Elasticsearch exporter
         prefix: {{ .Values.global.elasticsearch.prefix }}
+        {{- if .Values.global.elasticsearch.url }}
+        # Elasticsearch full url
+        url: {{ .Values.global.elasticsearch.url }}
+        {{- end }}
     logging:
 {{- with .Values.logging }}
 {{ . | toYaml | indent 6 }}

--- a/charts/zeebe-operate-helm/values.yaml
+++ b/charts/zeebe-operate-helm/values.yaml
@@ -5,6 +5,7 @@ global:
     port: 9200
     clusterName: "elasticsearch"
     prefix: zeebe-record
+    url:
 
 logging:
   level:


### PR DESCRIPTION
Parameterized full global elasticsearch URL. This setting will allow the use of URLs with "https".
If the value is not informed, the default is not to add this field to ConfigMap because the default value of the default values file is an empty string.