### PR TITLE
Fixing ingress version and adding new class parameter

### DIFF
--- a/charts/zeebe-operate-helm/templates/ingress.yaml
+++ b/charts/zeebe-operate-helm/templates/ingress.yaml
@@ -1,7 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else -}}
+{{- else }}
+apiVersion: networking.k8s.io/v1beta1
+{{- end }}
+{{- else }}
 apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
@@ -12,6 +16,9 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
 {{- end }}
 spec:
+  {{- if (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}
       http:

--- a/charts/zeebe-operate-helm/values.yaml
+++ b/charts/zeebe-operate-helm/values.yaml
@@ -28,6 +28,7 @@ resources:
 
 ingress:
   enabled: true
+  className: nginx
   annotations:
     kubernetes.io/ingress.class: nginx
     ingress.kubernetes.io/rewrite-target: "/"


### PR DESCRIPTION
## Fixing ingress version depending on Kubernetes version
`networking.k8s.io/v1beta1` is used from `1.14` to `1.18`.
`networking.k8s.io/v1` is used to `1.19+`

reference: https://kubernetes.io/docs/reference/using-api/deprecation-guide/

## Adding new parameter to inform ingress class
A new ingressClassName field has been added to the Ingress spec that is used to reference the IngressClass that should be used to implement this Ingress.

reference: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress