### PR TITLE
Parameterizing Zeebe cluster port

### DIFF
--- a/charts/zeebe-operate-helm/README.md
+++ b/charts/zeebe-operate-helm/README.md
@@ -39,7 +39,8 @@ This functionality is in beta and is subject to change. The design and code is l
 | `global.elasticsearch.host`         | ElasticSearch host to use in Elasticsearch Exporter connection  | `elasticsearch-master` |
 | `global.elasticsearch.port`         | ElasticSearch port to use in Elasticsearch Exporter connection | `9200` |
 | `global.elasticsearch.url`         | ElasticSearch full url to use in Elasticsearch Exporter connection. This config overrides the `host` and `port` above.  |  |
-| `zeebe`                 | Zeebe Cluster to connect Operate to                                                                                                                               |                                                                                                            |
+| `global.zeebe`                 | Zeebe Cluster to connect Operate to                                                                                                                               |                                                                                                            |
+| `global.zeebePort` | Zeebe Cluster Port to connect Operate to | `26500` |
 | `logging`               | Additional logging configuration                                                                                                                                  | `{level: { ROOT: INFO, org.camunda.operate: DEBUG }}`                                                     |
                                                                                                                                                                                                                                                                                                                 
 

--- a/charts/zeebe-operate-helm/templates/configmap.yaml
+++ b/charts/zeebe-operate-helm/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
       # Zeebe instance
       zeebe:
         # Broker contact point
-        brokerContactPoint: {{ tpl .Values.global.zeebe . }}-gateway:26500
+        brokerContactPoint: {{ tpl .Values.global.zeebe . }}-gateway:{{ .Values.global.zeebePort }}
       # ELS instance to export Zeebe data to
       zeebeElasticsearch:
         # Cluster name

--- a/charts/zeebe-operate-helm/values.yaml
+++ b/charts/zeebe-operate-helm/values.yaml
@@ -1,5 +1,6 @@
 global:
   zeebe: "{{ .Release.Name }}-zeebe"
+  zeebePort: 26500
   elasticsearch:
     host: "elasticsearch-master"
     port: 9200


### PR DESCRIPTION
- Adding possibility to change the port Operate uses to connect to Zeebe cluster gateway.
- Fixing Zeebe Cluster configuration parameters in README. Adding `global.` and new parameter `global.zeebePort`