### PR TITLE
feat: adds securityContext for the pod

### DIFF
--- a/charts/zeebe-cluster-helm/README.md
+++ b/charts/zeebe-cluster-helm/README.md
@@ -63,6 +63,7 @@ This functionality is in beta and is subject to change. The design and code is l
 | `nodeSelector`                 | Node selection constraint to schedule Zeebe on specific nodes                                                                                                                                | {}  
 | `tolerations`                 | Tolerations to allow Zeebe to run on dedicated nodes                                                                                                                                | []  
 | `affinity`                 | Use affinity constraints to schedule Zeebe on specific nodes                                                                                                                                | {}  
+| `securityContext`| Allows you to set the [securityContext][] for the pod                                                                                                                                                                                                                                                             | see [values.yaml][]                              |  
 | `gateway.replicas`         | The number of standalone gateways that should be deployed | `1`
 | `gateway.logLevel`         | The log level of the gateway, one of: ERROR, WARN, INFO, DEBUG, TRACE | `info` 
 | `gateway.log4j2`           | Log4J 2.x XML configuration; if provided, the contents given will be written to file and will overwrite the distribution's default `/usr/local/zeebe/config/log4j2.xml` | ``
@@ -170,3 +171,5 @@ Downloading kibana from repo https://helm.elastic.co
 Downloading kube-prometheus-stack from repo https://prometheus-community.github.io/helm-charts
 Deleting outdated charts
 ```
+
+[securityContext]: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/

--- a/charts/zeebe-cluster-helm/templates/statefulset.yaml
+++ b/charts/zeebe-cluster-helm/templates/statefulset.yaml
@@ -152,6 +152,10 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
 {{- end }}
+{{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+{{- end }}
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/charts/zeebe-cluster-helm/values.yaml
+++ b/charts/zeebe-cluster-helm/values.yaml
@@ -99,5 +99,11 @@ tolerations: []
 
 affinity: {}
 
+securityContext:
+  runAsUser: 9999
+  runAsGroup: 9999
+  fsGroup: 9999
+
+
 extraVolumes: {}
 extraVolumeMounts: {}


### PR DESCRIPTION
It adds the securityContext for the pod. 

Though I have some questions and doubts:

See https://github.com/camunda-community-hub/camunda-cloud-helm/blob/main/charts/zeebe-cluster-helm/templates/statefulset.yaml#L129 , this is actually setting the container security https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container , but the variable is named as podSecurityContext (also undocumented in the readme)

Do you think it's the wrong naming?  This adds some level of confusion as this PR adds the pod level security context, but now the naming clashes with the existing podSecurityContext

Any opinion how could this be rectified. Or please correct me if I am wrong :)