### PR TITLE
fix: set utf8 locale for zeebe

### DIFF
--- a/charts/zeebe-cluster-helm/templates/statefulset.yaml
+++ b/charts/zeebe-cluster-helm/templates/statefulset.yaml
@@ -42,6 +42,8 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
+        - name: LC_ALL
+          value: C.UTF-8
         - name: ZEEBE_BROKER_CLUSTER_CLUSTERNAME
           value: {{ tpl .Values.global.zeebe . }}
         - name: ZEEBE_LOG_LEVEL


### PR DESCRIPTION
Sets the default encoding to UTF-8, in the current release 1.3.0 the locale is not set which can cause data corruption.

Related to https://github.com/camunda-cloud/zeebe/pull/8580
