### PR TITLE
Create ccsm with subchart

### DIFF
--- a/charts/ccsm-helm/.helmignore
+++ b/charts/ccsm-helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ccsm-helm/Chart.yaml
+++ b/charts/ccsm-helm/Chart.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+name: ccsm-helm
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"
+
+dependencies:
+  - name: zeebe
+    version: 0.1.0
+    condition: zeebe.enabled

--- a/charts/ccsm-helm/charts/zeebe/.helmignore
+++ b/charts/ccsm-helm/charts/zeebe/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ccsm-helm/charts/zeebe/Chart.yaml
+++ b/charts/ccsm-helm/charts/zeebe/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+appVersion: "1.3.1"
+description: Zeebe Cluster Helm Chart for Kubernetes
+name: zeebe
+type: application
+version: 1.3.4
+icon: https://helm.camunda.io/imgs/zeebe-logo.png
+dependencies:
+- name: elasticsearch
+  repository: "https://helm.elastic.co"
+  version: 7.16.3
+  condition: "elasticsearch.enabled"
+- name: kibana
+  repository: "https://helm.elastic.co" 
+  version: 7.16.3
+  condition: "kibana.enabled"
+- name: kube-prometheus-stack
+  repository: "https://prometheus-community.github.io/helm-charts"
+  version: 12.0.X
+  condition: "prometheus.enabled"
+annotations:
+  artifacthub.io/changes: |
+    - support imagePullSecrets
+  artifacthub.io/containsSecurityUpdates: "false"

--- a/charts/ccsm-helm/charts/zeebe/README.md
+++ b/charts/ccsm-helm/charts/zeebe/README.md
@@ -1,0 +1,175 @@
+[![Community Extension](https://img.shields.io/badge/Community%20Extension-An%20open%20source%20community%20maintained%20project-FF4700)](https://github.com/camunda-community-hub/community)[![Lifecycle: Incubating](https://img.shields.io/badge/Lifecycle-Incubating-blue)](https://github.com/Camunda-Community-Hub/community/blob/main/extension-lifecycle.md#incubating-)[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+# Zeebe Cluster Helm Chart
+
+This functionality is in beta and is subject to change. The design and code is less mature than official GA features and is provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
+
+## Requirements
+
+* [Helm](https://helm.sh/) >= 3.x +
+* Kubernetes >= 1.18+
+* Minimum cluster requirements include the following to run this chart with default settings. All of these settings are configurable.
+  * Three Kubernetes nodes to respect the default "hard" affinity settings
+  * 1GB of RAM for the JVM heap
+
+
+## Installing
+
+* Add the official Zeebe helm charts repo
+
+  ```shell
+  helm repo add zeebe https://helm.camunda.io
+  ```
+
+* Install it
+
+  ```shell
+  helm install zb zeebe/zeebe-cluster-helm
+  ```
+
+ ## Configuration
+  | Parameter                     | Description                                                                                                                                                                                                                                                                                                                | Default                                                                                                                   |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `labels`                 | labels to be applied to the StatefulSet and Service                                                                                                                                | `app: zeebe`                                                                                                           |
+| `annotations`                 | annotations to be applied to the StatefulSet and Service                                                                                                                                | ``                                                                                                           |
+| `podAnnotations`                 | annotations to be applied to the StatefulSet pod Template                                                                                                                                | ``                                                                                                           |
+| `global.elasticsearch.disableExporter`                 | Disable [Elasticsearch Exporter](https://github.com/camunda-cloud/zeebe/tree/develop/exporters/elasticsearch-exporter) in Zeebe                                                                                                                                | `false`                                                                                                           |
+| `global.elasticsearch.host`         | ElasticSearch host to use in Elasticsearch Exporter connection  | `elasticsearch-master` |
+| `global.elasticsearch.port`         | ElasticSearch port to use in Elasticsearch Exporter connection | `9200` |
+| `global.elasticsearch.url`         | ElasticSearch full url to use in Elasticsearch Exporter connection. This config overrides the `host` and `port` above.  |  |
+| `elasticsearch.enabled`                 | Enable ElasticSearch deployment as part of the Zeebe Cluster                                                                                                                                | `true`                                                                                                           |
+| `kibana.enabled`                 | Enable Kibana deployment as part of the Zeebe Cluster                                                                                                                                | `false`                                                                                                           |
+| `prometheus.enabled`                 | Enable Prometheus operator as part of the Zeebe Cluster                                                                                                                          | `false`                                                                                                           |
+| `prometheus.servicemonitor.enabled`                 | Deploy a `ServiceMonitor` for your Zeebe Cluster                                                                                                                                 | `false`                                                                                                           |
+| `clusterSize`                 | Set the Zeebe Cluster Size and the number of replicas of the replica set                                                                                                                                | `3`
+| `partitionCount`                 | Set the Zeebe Cluster partition count                                                                                                                                | `3`
+| `replicationFactor`                 | Set the Zeebe Cluster replication factor                                                                                                                                | `3`
+| `cpuThreadCount`                 | Set the Zeebe Cluster CPU thread count                                                                                                                                | `2`
+| `ioThreadCount`                 | Set the Zeebe Cluster IO thread count                                                                                                                                | `2`
+| `zeebeCfg`                 | Can be used to set several zeebe configuration options.                                                                                                                                | `null`
+| `logLevel`                 | Sets the log level for io.zeebe packages; must be one of: ERROR, WARN, INFO, DEBUG, TRACE | `info`
+| `log4j2`                   | Log4J 2.x XML configuration; if provided, the contents given will be written to file and will overwrite the distribution's default `/usr/local/zeebe/config/log4j2.xml` | ``
+| `gatewayMetrics`                 | Enables the exporting of the gateway prometheus metrics                                                                                                                                | `false`
+| `JavaOpts`                 | Set the Zeebe Cluster Broker JavaOpts. This is where you should configure the jvm heap size.                                                                                                                                | `-XX:MaxRAMPercentage=25.0 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/zeebe/data -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log -XX:+ExitOnOutOfMemoryError`
+| `resources`                 | Set the Zeebe Cluster Broker Kubernetes Resource Request and Limits                                                                                                                                | `requests:`<br>  `cpu: 500m`<br>  ` memory: 1Gi`<br>`limits:`<br>  ` cpu: 1000m`<br>  ` memory: 2Gi`
+| `env`                       |  Pass additional environment variables to the Zeebe broker pods; <br> variables should be specified using standard Kubernetes raw YAML format. See below for an example.| `[]`
+| `podDisruptionBudget.enabled`         | Create a podDisruptionBudget for the broker pods | `false`
+| `podDisruptionBudget.minAvailable`         | Minimum number of available broker pods for PodDisruptionBudget |
+| `podDisruptionBudget.maxUnavailable`       | Maximum number of unavailable broker pods for PodDisruptionBudget | `1`
+| `podSecurityContext` | Sets the [securityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for the Zeebe pod. Can hold pod-level security attributes and common container settings. |  {}
+| `pvcSize`                 | Set the Zeebe Cluster Persistence Volume Claim Request storage size                                                                                                                                | `10Gi`
+| `pvcAccessModes`                 | Set the Zeebe Cluster Persistence Volume Claim Request accessModes                                                                                                                                | `[ "ReadWriteOnce" ]`
+| `pvcStorageClassName`                 | Set the Zeebe Cluster Persistence Volume Claim Request storageClassName                                                                                                                                | ``
+| `extraInitContainers`                 | add extra initContainers sections to StatefulSet                                                                                                                                | ``
+| `nodeSelector`                 | Node selection constraint to schedule Zeebe on specific nodes                                                                                                                                | {}
+| `priorityClassName`                 | Name of the priority class to assign on Zeebe pods                                                                                                                                | ``
+| `tolerations`                 | Tolerations to allow Zeebe to run on dedicated nodes                                                                                                                                | []
+| `affinity`                 | Use affinity constraints to schedule Zeebe on specific nodes                                                                                                                                | {}
+| `gateway.replicas`         | The number of standalone gateways that should be deployed | `1`
+| `gateway.priorityClassName`                 | Name of the priority class to assign on Zeebe gateway pods                                                                                                                                | ``
+| `gateway.logLevel`         | The log level of the gateway, one of: ERROR, WARN, INFO, DEBUG, TRACE | `info`
+| `gateway.log4j2`           | Log4J 2.x XML configuration; if provided, the contents given will be written to file and will overwrite the distribution's default `/usr/local/zeebe/config/log4j2.xml` | ``
+| `gateway.env`         |  Pass additional environment variables to the Zeebe broker pods; <br> variables should be specified using standard Kubernetes raw YAML format. See below for an example.| `[]`
+| `gateway.podAnnotations`         | Annotations to be applied to the gateway Deployment pod template | ``
+| `gateway.podDisruptionBudget.enabled`         | Create a PodDisruptionBudget for the gateway pods | `false`
+| `gateway.podDisruptionBudget.minAvailable`         | minimum number of available gateway pods for PodDisruptionBudget | `1`
+| `gateway.podDisruptionBudget.maxUnavailable`       | maximum number of unavailable gateway pods for PodDisruptionBudget |
+| `serviceType`         | The type of cluster service | `ClusterIP`
+| `serviceGatewayType`         | The type of cluster gateway service | `ClusterIP`
+| `serviceHttpPort`         | The http port used by the brokers and the gateway| `9600`
+| `serviceGatewayPort`         | The gateway port used by the gateway | `26500`
+| `serviceInternalPort`         | The internal port used by the brokers and the gateway | `26502`
+| `serviceCommandPort`         | The command port used the brokers | `26501`
+| `serviceHttpName`         | The http port name used by the brokers and the gateway| `http`
+| `serviceGatewayName`         | The gateway port name used by the gateway | `gateway`
+| `serviceInternalName`         | The internal port name used by the brokers and the gateway | `internal`
+| `serviceCommandName`         | The command port name used the brokers | `command`
+
+## Examples
+
+### Env Example
+```yaml
+
+env:
+  - name: ZEEBE_GATEWAY_MONITORING_ENABLED
+    value: "true"
+```
+
+
+## Adding dynamic exporters to Zeebe Brokers
+
+This chart supports the addition of Zeebe Exporters by using initContainer as shown in the following example:
+
+```
+extraInitContainers: |
+  - name: init-exporters-hazelcast
+    image: busybox:1.28
+    command: ['/bin/sh', '-c']
+    args: ['wget --no-check-certificate https://repo1.maven.org/maven2/io/zeebe/hazelcast/zeebe-hazelcast-exporter/0.8.0-alpha1/zeebe-hazelcast-exporter-0.8.0-alpha1-jar-with-dependencies.jar -O /exporters/zeebe-hazelcast-exporter.jar; ls -al']
+    volumeMounts:
+    - name: exporters
+      mountPath: /exporters/
+  - name: init-exporters-kafka
+    image: busybox:1.28
+    command: ['/bin/sh', '-c']
+    args: ['wget --no-check-certificate https://github.com/zeebe-io/zeebe-kafka-exporter/releases/download/1.1.0/zeebe-kafka-exporter-1.1.0-uber.jar -O /exporters/zeebe-kafka-exporter.jar; ls -al']
+    volumeMounts:
+    - name: exporters
+      mountPath: /exporters/
+env:
+  ZEEBE_BROKER_EXPORTERS_HAZELCAST_JARPATH: exporters/zeebe-hazelcast-exporter.jar
+  ZEEBE_BROKER_EXPORTERS_HAZELCAST_CLASSNAME: io.zeebe.hazelcast.exporter.HazelcastExporter
+  ZEEBE_HAZELCAST_REMOTE_ADDRESS: "{{ .Release.Name }}-hazelcast"
+```
+This example is downloading the exporters Jar from an URL and adding the Jars to the `exporters` directory that will be scanned for jars and added to the zeebe broker classpath. Then with `environment variables` you can configure the exporter parameters.
+
+## Dependencies
+
+This chart currently depends on the following charts:
+
+* [ElasticSearch Helm Chart](https://github.com/elastic/helm-charts/blob/master/elasticsearch/README.md)
+* [Kibana Helm Chart](https://github.com/elastic/helm-charts/tree/master/kibana)
+* [Prometheus Operator Helm Chart](https://github.com/helm/charts/tree/master/stable/prometheus-operator)
+
+These dependencies can be turned on or off and parameters can be overriden from these dependent charts by changing the `values.yaml` file. For example:
+
+```yaml
+elasticsearch:
+  enabled: true
+  imageTag: <YOUR VERSION HERE>
+kibana:
+  enabled: false
+```
+
+## Development
+
+For development purpose you might want to deploy and test the charts without creating a new release. In order to do this you can run the following:
+
+```sh
+ helm install <RELEASENAME> charts/zeebe-cluster-helm/
+```
+
+If you see errors like:
+
+```sh
+Error: found in Chart.yaml, but missing in charts/ directory: elasticsearch, kibana, kube-prometheus-stack
+```
+
+Then you need to download the depenencies first. You can do this via:
+
+```sh
+$ helm dependency update charts/zeebe-cluster-helm/
+Getting updates for unmanaged Helm repositories...
+...Successfully got an update from the "https://helm.elastic.co" chart repository
+...Successfully got an update from the "https://helm.elastic.co" chart repository
+...Successfully got an update from the "https://prometheus-community.github.io/helm-charts" chart repository
+Hang tight while we grab the latest from your chart repositories...
+...Successfully got an update from the "zeebe" chart repository
+...Successfully got an update from the "stable" chart repository
+Update Complete. ⎈Happy Helming!⎈
+Saving 3 charts
+Downloading elasticsearch from repo https://helm.elastic.co
+Downloading kibana from repo https://helm.elastic.co
+Downloading kube-prometheus-stack from repo https://prometheus-community.github.io/helm-charts
+Deleting outdated charts
+```

--- a/charts/ccsm-helm/charts/zeebe/templates/NOTES.txt
+++ b/charts/ccsm-helm/charts/zeebe/templates/NOTES.txt
@@ -1,0 +1,23 @@
+ ______     ______     ______     ______     ______    
+/\___  \   /\  ___\   /\  ___\   /\  == \   /\  ___\   
+\/_/  /__  \ \  __\   \ \  __\   \ \  __<   \ \  __\   
+  /\_____\  \ \_____\  \ \_____\  \ \_____\  \ \_____\ 
+  \/_____/   \/_____/   \/_____/   \/_____/   \/_____/                                                                                                                                      
+
+({{ .Chart.Name }} - {{ .Chart.Version }})
+
+- Docker Image used for Broker: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+- Cluster Name: {{ tpl .Values.global.zeebe . | quote }}
+- ElasticSearch Enabled: {{ .Values.elasticsearch.enabled }} - URL: http://{{ .Values.global.elasticsearch.host }}:{{ .Values.global.elasticsearch.port }}
+- Kibana Enabled: {{ .Values.kibana.enabled }}
+- Prometheus Enabled: {{ .Values.prometheus.enabled }}
+- Prometheus ServiceMonitor Enabled: {{ .Values.prometheus.servicemonitor.enabled }}
+
+The Cluster itself is not exposed as a service that means that you can use kubectl port-forward to access the Zeebe cluster from outside Kubernetes:
+
+> kubectl port-forward svc/{{ tpl .Values.global.zeebe . }}-gateway 26500:26500 -n {{ .Release.Namespace }}
+
+Now you can connect your workers and clients to `localhost:26500`
+
+
+

--- a/charts/ccsm-helm/charts/zeebe/templates/_helpers.tpl
+++ b/charts/ccsm-helm/charts/zeebe/templates/_helpers.tpl
@@ -1,0 +1,113 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "zeebe-cluster.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "zeebe-cluster.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "zeebe-gateway.fullname" -}}
+{{- if .Values.gateway.fullnameOverride -}}
+{{- .Values.gateway.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Release.Name (tpl .Values.global.zeebe .) -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-gateway" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "zeebe-cluster.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "zeebe-cluster.labels" -}}
+app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "zeebe-cluster.version" -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+
+{{- define "zeebe-cluster.labels.broker" -}}
+{{- template "zeebe-cluster.labels" . }}
+app.kubernetes.io/component: broker
+{{- end -}}
+
+{{- define "zeebe-cluster.labels.gateway" -}}
+{{- template "zeebe-cluster.labels" . }}
+app.kubernetes.io/component: gateway
+{{- end -}}
+
+{{/*
+Common names
+*/}}
+{{- define "zeebe-cluster.names.broker" -}}
+{{- if .Values.global.zeebe -}}
+{{- tpl .Values.global.zeebe . | trunc 63 | trimSuffix "-" | quote -}}
+{{- else -}}
+{{- printf "%s-broker" .Release.Name | trunc 63 | trimSuffix "-" | quote -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Creates a valid DNS name for the gateway
+*/}}
+{{- define "zeebe-cluster.names.gateway" -}}
+{{- $name := default .Release.Name (tpl .Values.global.zeebe .) -}}
+{{- printf "%s-gateway" $name | trunc 63 | trimSuffix "-" | quote -}}
+{{- end -}}
+{{/*
+[zeebe-cluster] Create the name of the service account to use
+*/}}
+{{- define "zeebe-cluster.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "zeebe-cluster.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+[zeebe-gateway] Create the name of the service account to use
+*/}}
+{{- define "zeebe-gateway.serviceAccountName" -}}
+{{- if .Values.gateway.serviceAccount.create }}
+{{- default (include "zeebe-gateway.fullname" .) .Values.gateway.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.gateway.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/ccsm-helm/charts/zeebe/templates/configmap.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/configmap.yaml
@@ -1,0 +1,54 @@
+kind: ConfigMap
+metadata:
+  name: {{ include "zeebe-cluster.fullname" . }}
+  labels: 
+    {{- include "zeebe-cluster.labels" . | nindent 4 }}
+apiVersion: v1
+data:
+  startup.sh: |
+    #!/usr/bin/env bash
+    set -eux -o pipefail
+
+    export ZEEBE_BROKER_NETWORK_ADVERTISEDHOST=${ZEEBE_BROKER_NETWORK_ADVERTISEDHOST:-$(hostname -f)}
+    export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-${K8S_POD_NAME##*-}}
+
+    # As the number of replicas or the DNS is not obtainable from the downward API yet,
+    # defined them here based on conventions
+    export ZEEBE_BROKER_CLUSTER_CLUSTERSIZE=${ZEEBE_BROKER_CLUSTER_CLUSTERSIZE:-1}
+    contactPointPrefix=${K8S_POD_NAME%-*}
+    contactPoints=${ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS:-""}
+    if [[ -z "${contactPoints}" ]]; then
+      for ((i=0; i<${ZEEBE_BROKER_CLUSTER_CLUSTERSIZE}; i++))
+      do
+        contactPoints="${contactPoints},${contactPointPrefix}-$i.$(hostname -d):{{ .Values.serviceInternalPort }}"
+      done
+
+      export ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS="${contactPoints}"
+    fi
+    
+    if [ "$(ls -A /exporters/)" ]; then
+      mkdir /usr/local/zeebe/exporters/
+      cp -a /exporters/*.jar /usr/local/zeebe/exporters/
+    else  
+      echo "No exporters available."
+    fi
+
+    exec /usr/local/zeebe/bin/broker
+
+  application.yaml: |
+{{- if .Values.zeebeCfg }}
+{{- with .Values.zeebeCfg }}
+{{ . | toYaml | indent 4 }}
+{{- end }}
+{{- end }}
+
+  broker-log4j2.xml: |
+{{- if .Values.log4j2 }}
+    {{ .Values.log4j2 | indent 4 | trim }}
+{{- end }}
+
+  gateway-log4j2.xml: |
+{{- if .Values.gateway.log4j2 }}
+    {{ .Values.gateway.log4j2 | indent 4 | trim }}
+{{- end }}
+

--- a/charts/ccsm-helm/charts/zeebe/templates/gateway-deployment.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/gateway-deployment.yaml
@@ -1,0 +1,120 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "zeebe-cluster.names.gateway" . }}
+  labels:
+    {{- include "zeebe-cluster.labels.gateway" . | nindent 4 }}
+  annotations:
+      {{- range $key, $value := .Values.gateway.annotations }}
+      {{ $key }}: {{ $value | quote }}
+      {{- end }}
+spec:
+  replicas: {{ .Values.gateway.replicas  }}
+  selector:
+    matchLabels:
+      {{- include "zeebe-cluster.labels.gateway" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "zeebe-cluster.labels.gateway" . | nindent 8 }}
+        {{- if .Values.gateway.podLabels }}
+        {{- toYaml .Values.gateway.podLabels | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- range $key, $value := .Values.gateway.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    spec:
+      {{- if .Values.gateway.priorityClassName }}
+      priorityClassName: {{ .Values.gateway.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{ toYaml .Values.image.pullSecrets | indent 8 | trim }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{  .Values.serviceHttpPort }}
+              name: {{  default "http" .Values.serviceHttpName }}
+            - containerPort: {{  .Values.serviceGatewayPort }}
+              name: {{ default "gateway" .Values.serviceGatewayName  }}
+            - containerPort: {{  .Values.serviceInternalPort }}
+              name: {{ default "internal" .Values.serviceInternalName  }}
+          env:
+            - name: ZEEBE_STANDALONE_GATEWAY
+              value: "true"
+            - name: ZEEBE_GATEWAY_CLUSTER_CLUSTERNAME
+              value: {{ tpl .Values.global.zeebe . }}
+            - name: ZEEBE_GATEWAY_CLUSTER_MEMBERID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_LOG_LEVEL
+              value: {{ .Values.gateway.logLevel | quote }}
+            - name: JAVA_TOOL_OPTIONS
+              value: {{ .Values.JavaOpts | quote }}
+            - name: ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT
+              value: {{ tpl .Values.global.zeebe . }}:{{ .Values.serviceInternalPort }}
+            - name: ZEEBE_GATEWAY_NETWORK_HOST
+              value: 0.0.0.0
+            - name: ZEEBE_GATEWAY_NETWORK_PORT
+              value: {{  .Values.serviceGatewayPort | quote }}
+            - name: ZEEBE_GATEWAY_CLUSTER_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: ZEEBE_GATEWAY_CLUSTER_PORT
+              value: {{  .Values.serviceInternalPort | quote }}
+            - name: ZEEBE_GATEWAY_MONITORING_HOST
+              value: 0.0.0.0
+            - name: ZEEBE_GATEWAY_MONITORING_PORT
+              value: {{  .Values.serviceHttpPort | quote }}
+            {{- if .Values.gateway.env }}
+            {{ toYaml .Values.gateway.env | indent 12 | trim }}
+            {{- end }}
+          volumeMounts:
+            {{- if .Values.gateway.log4j2 }}
+            - name: config
+              mountPath: /usr/local/zeebe/config/log4j2.xml
+              subPath: gateway-log4j2.xml
+            {{- end }}
+            {{- if .Values.extraGatewayVolumeMounts}}
+            {{ .Values.extraGatewayVolumeMounts | toYaml | nindent 12 }}
+            {{- end }}
+          securityContext:
+            {{ toYaml .Values.podSecurityContext | indent 12 | trim }}
+          readinessProbe:
+            tcpSocket:
+              port: {{ default "gateway" .Values.serviceGatewayName  }}
+            initialDelaySeconds: 20
+            periodSeconds: 5
+          {{- if .Values.gateway.resources}}
+          resources:
+            {{- toYaml .Values.gateway.resources | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "zeebe-cluster.fullname" . }}
+            defaultMode: 0744
+        {{- if .Values.extraGatewayVolumes}}
+        {{ .Values.extraGatewayVolumes | toYaml | nindent 8 }}
+        {{- end }}
+      {{- if .Values.serviceAccount.name}}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
+{{- with .Values.gateway.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.gateway.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.gateway.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}

--- a/charts/ccsm-helm/charts/zeebe/templates/gateway-poddisruptionbudget.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/gateway-poddisruptionbudget.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.gateway.podDisruptionBudget.enabled  }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ printf "%s-gateway" (tpl .Values.global.zeebe .) | quote }}
+  labels:
+    {{- include "zeebe-cluster.labels.gateway" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.gateway.podDisruptionBudget.minAvailable }}
+  maxUnavailable: {{ .Values.gateway.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "zeebe-cluster.labels.gateway" . | nindent 6 }}
+{{ end }}

--- a/charts/ccsm-helm/charts/zeebe/templates/gateway-service.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/gateway-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "zeebe-cluster.names.gateway" . }}
+  labels:
+    {{- include "zeebe-cluster.labels.gateway" . | nindent 4 }}
+  annotations:
+    {{- toYaml  .Values.annotations | nindent 4 }}
+spec:
+  type: {{ .Values.serviceGatewayType }}
+  selector:
+    {{- include "zeebe-cluster.labels.gateway" . | nindent 6 }}
+  ports:
+    - port: {{ .Values.serviceHttpPort }}
+      protocol: TCP
+      name: {{ default "http" .Values.serviceHttpName  }}
+    - port: {{ .Values.serviceGatewayPort }}
+      protocol: TCP
+      name: {{ default "gateway" .Values.serviceGatewayName }}

--- a/charts/ccsm-helm/charts/zeebe/templates/gateway-serviceaccount.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/gateway-serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.gateway.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "zeebe-gateway.serviceAccountName" . }}
+  labels:
+    {{- include "zeebe-cluster.labels.gateway" . | nindent 4 }}
+  {{- with .Values.gateway.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/ccsm-helm/charts/zeebe/templates/poddisruptionbudget.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/poddisruptionbudget.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "zeebe-cluster.names.broker" . }}
+  labels:
+    {{- include "zeebe-cluster.labels.broker" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "zeebe-cluster.labels.broker" . | nindent 6 }}
+{{ end }}

--- a/charts/ccsm-helm/charts/zeebe/templates/service-monitor.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/service-monitor.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.prometheus.servicemonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "zeebe-cluster.fullname" . }}
+  labels:
+    {{- include "zeebe-cluster.labels" . | nindent 4 }}
+    release: metrics
+spec:
+  selector:
+    matchLabels:
+      {{- include "zeebe-cluster.labels" . | nindent 6 }}
+  endpoints:
+    - honorLabels: true
+      port: http
+      interval: 10s
+{{- end }}

--- a/charts/ccsm-helm/charts/zeebe/templates/service.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "zeebe-cluster.names.broker" . }}
+  labels:
+    {{- include "zeebe-cluster.labels.broker" . | nindent 4 }}
+    {{- toYaml  .Values.labels | nindent 4 }}
+  annotations:
+    {{- toYaml  .Values.annotations | nindent 4 }}    
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: {{ .Values.serviceType }}
+  ports:
+    - port: {{ .Values.serviceHttpPort }}
+      protocol: TCP
+      name: {{ default "http" .Values.serviceHttpName  }}  
+    - port: {{ .Values.serviceInternalPort }}
+      protocol: TCP
+      name: {{ default "internal" .Values.serviceInternalName  }}
+    - port: {{ .Values.serviceCommandPort }}
+      protocol: TCP
+      name: {{ default "command" .Values.serviceCommandName }}
+  selector:
+    {{- include "zeebe-cluster.labels.broker" . | nindent 4 }}

--- a/charts/ccsm-helm/charts/zeebe/templates/serviceaccount.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "zeebe-cluster.serviceAccountName" . }}
+  labels:
+    {{- include "zeebe-cluster.labels.broker" . | nindent 4 }}
+    {{- toYaml  .Values.labels | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/ccsm-helm/charts/zeebe/templates/statefulset.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/statefulset.yaml
@@ -1,0 +1,172 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "zeebe-cluster.names.broker" . }}
+  labels:
+    {{- include "zeebe-cluster.labels.broker" . | nindent 4 }}
+    {{- toYaml  .Values.labels | nindent 4 }}
+  annotations:
+    {{- range $key, $value := .Values.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  replicas: {{ .Values.clusterSize  }}
+  selector:
+    matchLabels:
+      {{- include "zeebe-cluster.labels.broker" . | nindent 6 }}
+  serviceName: {{ include "zeebe-cluster.names.broker" . }}
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        {{- include "zeebe-cluster.labels.broker" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{ toYaml .Values.image.pullSecrets | indent 8 | trim }}
+      {{- end }}
+      initContainers:
+        {{- if .Values.extraInitContainers }}
+        {{ tpl .Values.extraInitContainers . | indent 8 | trim }}
+        {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: LC_ALL
+          value: C.UTF-8
+        - name: ZEEBE_BROKER_CLUSTER_CLUSTERNAME
+          value: {{ tpl .Values.global.zeebe . }}
+        - name: ZEEBE_LOG_LEVEL
+          value: {{ .Values.logLevel | quote }}
+        - name: ZEEBE_BROKER_CLUSTER_PARTITIONSCOUNT
+          value: {{ .Values.partitionCount | quote }}
+        - name: ZEEBE_BROKER_CLUSTER_CLUSTERSIZE
+          value: {{ .Values.clusterSize | quote }}
+        - name: ZEEBE_BROKER_CLUSTER_REPLICATIONFACTOR
+          value: {{ .Values.replicationFactor | quote }}
+        - name: ZEEBE_BROKER_THREADS_CPUTHREADCOUNT
+          value: {{ .Values.cpuThreadCount  | quote }}
+        - name: ZEEBE_BROKER_THREADS_IOTHREADCOUNT
+          value: {{ .Values.ioThreadCount  | quote }}
+        - name: ZEEBE_BROKER_GATEWAY_ENABLE
+          value: "false"
+        {{- if not .Values.global.elasticsearch.disableExporter }}
+        - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME
+          value: "io.camunda.zeebe.exporter.ElasticsearchExporter"
+        {{- if .Values.global.elasticsearch.url }}
+        - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL
+          value: {{ .Values.global.elasticsearch.url | quote }}
+        {{- else }}
+        - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL
+          value: "http://{{ .Values.global.elasticsearch.host }}:{{ .Values.global.elasticsearch.port }}"
+        {{- end }}
+        {{- end }}
+        - name: ZEEBE_BROKER_NETWORK_COMMANDAPI_PORT
+          value: {{ .Values.serviceCommandPort  | quote }}
+        - name: ZEEBE_BROKER_NETWORK_INTERNALAPI_PORT
+          value: {{  .Values.serviceInternalPort | quote }}
+        - name: ZEEBE_BROKER_NETWORK_MONITORINGAPI_PORT
+          value: {{  .Values.serviceHttpPort | quote }}
+        - name: K8S_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: JAVA_TOOL_OPTIONS
+          value: {{ .Values.JavaOpts | quote }}
+      {{- if .Values.envTemplated }}
+        {{- range $key, $value := .Values.envTemplated }}
+        - name: {{ $key }}
+          value: {{ tpl ($value | toString) $ }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.env }}
+        {{ toYaml .Values.env | indent 8 | trim }}
+      {{- end }}
+        {{- if .Values.command}}
+        command: {{ .Values.command }}
+        {{- end }}
+        ports:
+        - containerPort: {{ .Values.serviceHttpPort  }}
+          name: {{ default "http" .Values.serviceHttpName  }}
+        - containerPort: {{ .Values.serviceCommandPort  }}
+          name: {{ default "command" .Values.serviceCommandName  }}
+        - containerPort: {{ .Values.serviceInternalPort  }}
+          name: {{ default "internal" .Values.serviceInternalName  }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.probePath }}
+            port: {{ .Values.serviceHttpPort }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+        volumeMounts:
+        - name: config
+          mountPath: /usr/local/zeebe/config/application.yaml
+          subPath: application.yaml
+        - name: config
+          mountPath: /usr/local/bin/startup.sh
+          subPath: startup.sh
+        - name: data
+          mountPath: /usr/local/zeebe/data
+        - name: exporters
+          mountPath: /exporters
+        {{- if .Values.log4j2 }}
+        - name: config
+          mountPath: /usr/local/zeebe/config/log4j2.xml
+          subPath: broker-log4j2.xml
+        {{- end }}
+        {{- if .Values.extraVolumeMounts}}
+        {{ .Values.extraVolumeMounts | toYaml | nindent 8 }}
+        {{- end }}
+        securityContext:
+          {{ toYaml .Values.podSecurityContext | indent 12 | trim }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "zeebe-cluster.fullname" . }}
+          defaultMode: 0744
+      - name: exporters
+        emptyDir: {}
+      {{- if .Values.extraVolumes}}
+      {{ .Values.extraVolumes | toYaml | nindent 6 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: {{ .Values.pvcAccessModes }}
+      storageClassName: {{ .Values.pvcStorageClassName }}
+      resources:
+        requests:
+          storage: {{ .Values.pvcSize | quote }}

--- a/charts/ccsm-helm/charts/zeebe/templates/tests/test-connection.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ tpl .Values.global.zeebe . }}-test-connection"
+  labels:
+{{ include "zeebe-cluster.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['{{ tpl .Values.global.zeebe . }}:{{ .Values.serviceHttpPort }}']
+  restartPolicy: Never

--- a/charts/ccsm-helm/charts/zeebe/values.yaml
+++ b/charts/ccsm-helm/charts/zeebe/values.yaml
@@ -1,0 +1,107 @@
+# Default values for zeebe-cluster-helm.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Annotations to apply to the statefullset
+annotations: {}
+
+global:
+  elasticsearch:
+    url:
+    host: "elasticsearch-master"
+    port: 9200
+  zeebe: "{{ .Release.Name }}-zeebe"
+
+image:
+  repository: camunda/zeebe
+  tag: 1.3.1
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+  #  - name: myregistrykey
+
+clusterSize: "3"
+partitionCount: "3"
+replicationFactor: "3"
+cpuThreadCount: "2"
+ioThreadCount: "2"
+pvcSize: "10Gi"
+pvcAccessModes: [ "ReadWriteOnce" ]
+env: []
+logLevel: info
+
+gateway:
+  annotations: {}
+  replicas: 1
+  logLevel: info
+  env: []
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    maxUnavailable:
+  priorityClassName: ""
+  resources:  {}
+  serviceAccount:
+    create: true
+    name: ""
+    annotations: {}
+
+elasticsearch:
+  enabled: true
+  imageTag: 7.16.2
+
+kibana:
+  enabled: false
+  imageTag: 7.16.2
+
+prometheus:
+  enabled: false
+  servicemonitor:
+    enabled: false
+
+JavaOpts: >-
+  -XX:MaxRAMPercentage=25.0
+  -XX:+HeapDumpOnOutOfMemoryError
+  -XX:HeapDumpPath=/usr/local/zeebe/data
+  -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log
+  -XX:+ExitOnOutOfMemoryError
+
+labels:
+  app: zeebe
+serviceType: ClusterIP
+serviceGatewayType: ClusterIP
+serviceHttpPort: 9600
+serviceGatewayPort: 26500
+serviceCommandPort: 26501
+serviceInternalPort: 26502
+priorityClassName: ""
+resources:
+  requests:
+    cpu: 500m
+    memory: 2Gi
+  limits:
+    cpu: 1000m
+    memory: 4Gi
+probePath: /ready
+readinessProbe:
+  failureThreshold: 1
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+podDisruptionBudget:
+  enabled: false
+  minAvailable:
+  maxUnavailable: 1
+podSecurityContext: {}
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+extraVolumes: {}
+extraVolumeMounts: {}

--- a/charts/ccsm-helm/values.yaml
+++ b/charts/ccsm-helm/values.yaml
@@ -1,0 +1,7 @@
+# Default values for ccsm-helm.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+#
+#
+zeebe:
+  enabled: true


### PR DESCRIPTION
As our requirements are to be able to disable components like tasklist, operate etc. it would make more sense to use inside the chart subcharts, which allows to define condition whether they are included in the deployment or not, Otherwise I see no possibility to disable deployments/resource in one single chart.


Example:

```
[zell charts/ cluster: zeebe-cluster ns:default]$ helm template test ccsm-helm/ | grep Source
# Source: ccsm-helm/charts/zeebe/charts/elasticsearch/templates/poddisruptionbudget.yaml
# Source: ccsm-helm/charts/zeebe/templates/gateway-serviceaccount.yaml
# Source: ccsm-helm/charts/zeebe/templates/serviceaccount.yaml
# Source: ccsm-helm/charts/zeebe/templates/configmap.yaml
# Source: ccsm-helm/charts/zeebe/charts/elasticsearch/templates/service.yaml
# Source: ccsm-helm/charts/zeebe/charts/elasticsearch/templates/service.yaml
# Source: ccsm-helm/charts/zeebe/templates/gateway-service.yaml
# Source: ccsm-helm/charts/zeebe/templates/service.yaml
# Source: ccsm-helm/charts/zeebe/templates/gateway-deployment.yaml
# Source: ccsm-helm/charts/zeebe/charts/elasticsearch/templates/statefulset.yaml
# Source: ccsm-helm/charts/zeebe/templates/statefulset.yaml
# Source: ccsm-helm/charts/zeebe/charts/elasticsearch/templates/test/test-elasticsearch-health.yaml
# Source: ccsm-helm/charts/zeebe/templates/tests/test-connection.yaml

```

Disable zeebe:

```
[zell charts/ cluster: zeebe-cluster ns:default]$ helm template test ccsm-helm/ --set zeebe.enabled=false



```