### PR TITLE
Add operate sub chart

### DIFF
--- a/charts/ccsm-helm/Chart.yaml
+++ b/charts/ccsm-helm/Chart.yaml
@@ -7,7 +7,7 @@ version: 0.0.1
 icon: https://helm.camunda.io/imgs/camunda-cloud.png
 dependencies:
 - name: zeebe
-  version: 1.3.4
+  version: 0.0.1
   condition: "zeebe.enabled"
 - name: elasticsearch
   repository: "https://helm.elastic.co"

--- a/charts/ccsm-helm/Chart.yaml
+++ b/charts/ccsm-helm/Chart.yaml
@@ -9,6 +9,9 @@ dependencies:
 - name: zeebe
   version: 0.0.1
   condition: "zeebe.enabled"
+- name: operate
+  version: 0.0.1
+  condition: "operate.enabled"
 - name: elasticsearch
   repository: "https://helm.elastic.co"
   version: 7.16.3

--- a/charts/ccsm-helm/Chart.yaml
+++ b/charts/ccsm-helm/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.3.1"
 description: Camunda Cloud Self-Managed Helm Chart for Kubernetes
 name: ccsm-helm
 type: application
-version: 0.0.1
+version: 0.0.2
 icon: https://helm.camunda.io/imgs/camunda-cloud.png
 dependencies:
 - name: zeebe
@@ -26,5 +26,7 @@ dependencies:
   condition: "prometheus.enabled"
 annotations:
   artifacthub.io/changes: |
-    - initial ccsm setup with zeebe only support
+    - add operate as sub chart
+    - add new notes file for better usability
+    - adjust some properties in zeebe chart
   artifacthub.io/containsSecurityUpdates: "false"

--- a/charts/ccsm-helm/charts/operate/.helmignore
+++ b/charts/ccsm-helm/charts/operate/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ccsm-helm/charts/operate/Chart.yaml
+++ b/charts/ccsm-helm/charts/operate/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+appVersion: "1.3.1"
+description: Operate Helm Chart for Kubernetes
+name: operate
+version: 0.0.1
+type: application
+icon: https://raw.githubusercontent.com/camunda-cloud/camunda-cloud-documentation/master/static/img/camunda-operate-gradient.png
+annotations:
+  artifacthub.io/changes: |
+    - create operate sub chart
+  artifacthub.io/containsSecurityUpdates: "false"

--- a/charts/ccsm-helm/charts/operate/README.md
+++ b/charts/ccsm-helm/charts/operate/README.md
@@ -1,0 +1,47 @@
+[![Community Extension](https://img.shields.io/badge/Community%20Extension-An%20open%20source%20community%20maintained%20project-FF4700)](https://github.com/camunda-community-hub/community)[![Lifecycle: Incubating](https://img.shields.io/badge/Lifecycle-Incubating-blue)](https://github.com/Camunda-Community-Hub/community/blob/main/extension-lifecycle.md#incubating-)[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+# Operate Helm Chart
+
+This functionality is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
+
+## Requirements
+
+* [Helm](https://helm.sh/) >= 3.x +
+* Kubernetes >= 1.8
+* Minimum cluster requirements include the following to run this chart with default settings. All of these settings are configurable.
+  * Three Kubernetes nodes to respect the default "hard" affinity settings
+  * 1GB of RAM for the JVM heap
+
+## Usage notes and getting started
+
+## Installing
+
+* Add the official zeebe helm charts repo
+```shell
+helm repo add camunda-cloud https://helm.camunda.io
+```
+
+* Install it
+```shell
+helm install operate camunda-cloud/operate --set global.zeebe=<YOUR ZEEBE CLUSTER NAME>
+```
+
+  Example if you installed the `zeebe-cluster-helm` chart manually with the name: `zb`
+
+   ```
+  helm install zeebe-operate zeebe/zeebe-operate --set global.zeebe=zb-zeebe
+  ```
+
+  > Note that you can find the Zeebe Cluster name by doing `kubectl get services` and copy the name of the Zeebe service, which will include the Helm Release name used to install the cluster. 
+
+ ## Configuration
+  | Parameter                     | Description                                                                                                                                                                                                                                                                                                                | Default                                                                                                                   |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `global.elasticsearch.host`         | ElasticSearch host to use in Elasticsearch Exporter connection  | `elasticsearch-master` |
+| `global.elasticsearch.port`         | ElasticSearch port to use in Elasticsearch Exporter connection | `9200` |
+| `global.elasticsearch.url`         | ElasticSearch full url to use in Elasticsearch Exporter connection. This config overrides the `host` and `port` above.  |  |
+| `global.zeebe`                 | Zeebe Cluster to connect Operate to                                                                                                                               |                                                                                                            |
+| `global.zeebePort` | Zeebe Cluster Port to connect Operate to | `26500` |
+| `logging`               | Additional logging configuration                                                                                                                                  | `{level: { ROOT: INFO, org.camunda.operate: DEBUG }}`                                                     |
+                                                                                                                                                                                                                                                                                                                
+

--- a/charts/ccsm-helm/charts/operate/templates/NOTES.txt
+++ b/charts/ccsm-helm/charts/operate/templates/NOTES.txt
@@ -1,0 +1,21 @@
+ ______     ______   ______     ______     ______     ______   ______    
+/\  __ \   /\  == \ /\  ___\   /\  == \   /\  __ \   /\__  _\ /\  ___\   
+\ \ \/\ \  \ \  _-/ \ \  __\   \ \  __<   \ \  __ \  \/_/\ \/ \ \  __\   
+ \ \_____\  \ \_\    \ \_____\  \ \_\ \_\  \ \_\ \_\    \ \_\  \ \_____\ 
+  \/_____/   \/_/     \/_____/   \/_/ /_/   \/_/\/_/     \/_/   \/_____/ 
+
+
+({{ .Chart.Name }} - {{ .Chart.Version }})
+
+- Docker Image used for Operate: {{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}
+- Zeebe Cluster Name: {{ tpl .Values.global.zeebeClusterName . }}
+- ElasticSearch URL: http://{{ .Values.global.elasticsearch.host }}:{{ .Values.global.elasticsearch.port }}
+
+As part of the Operate HELM Chart an Ingress definition is deployed, but you require to have an Ingress Contoller for that Ingress to be Exposed.
+If you don't have an Ingress Controller you can do kubectl port-forward to access Operate from outside the cluster:
+
+> kubectl port-forward svc/{{ include "zeebe-operate.fullname" . }} 8080:80
+
+Now you can point your browser to `http://localhost:8080`
+
+Default user and password: "demo/demo"

--- a/charts/ccsm-helm/charts/operate/templates/_helpers.tpl
+++ b/charts/ccsm-helm/charts/operate/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "zeebe-operate.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "zeebe-operate.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "zeebe-operate.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "zeebe-operate.labels" -}}
+app.kubernetes.io/name: {{ include "zeebe-operate.name" . }}
+helm.sh/chart: {{ include "zeebe-operate.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+[zeebe-operate] Create the name of the service account to use
+*/}}
+{{- define "zeebe-operate.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "zeebe-operate.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/ccsm-helm/charts/operate/templates/configmap.yaml
+++ b/charts/ccsm-helm/charts/operate/templates/configmap.yaml
@@ -1,0 +1,44 @@
+kind: ConfigMap
+metadata:
+  name: {{ include "zeebe-operate.fullname" . }}
+apiVersion: v1
+data:
+  application.yml: |
+    # Operate configuration file
+    camunda.operate:
+      # ELS instance to store Operate data
+      elasticsearch:
+        # Cluster name
+        clusterName: {{ .Values.global.elasticsearch.clusterName }}
+        # Host
+        host: {{ .Values.global.elasticsearch.host }}
+        # Transport port
+        port: {{ .Values.global.elasticsearch.port }}
+        {{- if .Values.global.elasticsearch.url }}
+        # Elasticsearch full url
+        url: {{ .Values.global.elasticsearch.url }}
+        {{- end }}
+      # Zeebe instance
+      zeebe:
+        # Broker contact point
+        brokerContactPoint: "{{ tpl .Values.global.zeebeClusterName . }}-gateway:{{ .Values.global.zeebePort }}"
+      # ELS instance to export Zeebe data to
+      zeebeElasticsearch:
+        # Cluster name
+        clusterName: {{ .Values.global.elasticsearch.clusterName }}
+        # Host
+        host: {{ .Values.global.elasticsearch.host }}
+        # Transport port
+        port: {{ .Values.global.elasticsearch.port }}
+        # Index prefix, configured in Zeebe Elasticsearch exporter
+        prefix: {{ .Values.global.elasticsearch.prefix }}
+        {{- if .Values.global.elasticsearch.url }}
+        # Elasticsearch full url
+        url: {{ .Values.global.elasticsearch.url }}
+        {{- end }}
+    logging:
+{{- with .Values.logging }}
+{{ . | toYaml | indent 6 }}
+{{- end }}
+    #Spring Boot Actuator endpoints to be exposed
+    management.endpoints.web.exposure.include: health,info,conditions,configprops,prometheus

--- a/charts/ccsm-helm/charts/operate/templates/deployment.yaml
+++ b/charts/ccsm-helm/charts/operate/templates/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "zeebe-operate.fullname" . }}
+  labels:
+    app: {{ include "zeebe-operate.fullname" . }}
+    {{- if .Values.labels }}
+    {{- toYaml .Values.labels | nindent 4 }}
+    {{- end }}
+  annotations:
+      {{- range $key, $value := .Values.annotations }}
+      {{ $key }}: {{ $value | quote }}
+      {{- end }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "zeebe-operate.fullname" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "zeebe-operate.fullname" . }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}"
+        {{- if .Values.env}}
+        env:
+        {{ .Values.env | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if .Values.command}}
+        command: {{ .Values.command }}
+        {{- end }}
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        volumeMounts:
+        - name: config
+          mountPath: /usr/local/operate/config/application.yml
+          subPath: application.yml
+        {{- if .Values.extraVolumeMounts}}
+        {{ .Values.extraVolumeMounts | toYaml | nindent 8 }}
+        {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "zeebe-operate.fullname" . }}
+          defaultMode: 0744
+      {{- if .Values.extraVolumes}}
+      {{ .Values.extraVolumes | toYaml | nindent 6 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.name}}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}

--- a/charts/ccsm-helm/charts/operate/templates/ingress.yaml
+++ b/charts/ccsm-helm/charts/operate/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "zeebe-operate.fullname" . }}
+  labels: {{ include "zeebe-operate.labels" . | nindent 4 }}
+{{- with .Values.ingress.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+{{- end }}
+spec:
+  {{- if (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "zeebe-operate.fullname" . }}
+                port:
+                  number: 80
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      {{- if .Values.ingress.tls.secretName }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/ccsm-helm/charts/operate/templates/service.yaml
+++ b/charts/ccsm-helm/charts/operate/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "zeebe-operate.fullname" . }}
+  labels:
+    app: {{ include "zeebe-operate.fullname" . }}
+    {{- if .Values.labels }}
+    {{- toYaml .Values.labels | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.port }}
+    name: http
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    app: {{ include "zeebe-operate.fullname" . }}

--- a/charts/ccsm-helm/charts/operate/templates/serviceaccount.yaml
+++ b/charts/ccsm-helm/charts/operate/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "zeebe-operate.serviceAccountName" . }}
+  labels:
+    app: {{ include "zeebe-operate.fullname" . }}
+    {{- if .Values.labels }}
+    {{- toYaml .Values.labels | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/ccsm-helm/charts/operate/templates/tests/test-connection.yaml
+++ b/charts/ccsm-helm/charts/operate/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "zeebe-operate.fullname" . }}-test-connection"
+  labels:
+{{ include "zeebe-operate.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['{{ include "zeebe-operate.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/ccsm-helm/charts/operate/values.yaml
+++ b/charts/ccsm-helm/charts/operate/values.yaml
@@ -1,0 +1,49 @@
+global:
+  image:
+    # global.image.repository overwrites the default repository to the operate image
+    repository: camunda/operate
+
+
+# Annotations to apply to the deployment
+annotations: {}
+labels:
+
+logging:
+  level:
+    ROOT: INFO
+    org.camunda.operate: DEBUG
+
+service:
+  type: ClusterIP
+  port: 80
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 1Gi
+  limits:
+    cpu: 1000m
+    memory: 2Gi
+
+env:
+extraVolumes:
+extraVolumeMounts:
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    ingress.kubernetes.io/rewrite-target: "/"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+  path: /
+  host:
+  tls:
+    enabled: false
+    secretName:
+
+podSecurityContext:

--- a/charts/ccsm-helm/charts/zeebe/Chart.yaml
+++ b/charts/ccsm-helm/charts/zeebe/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.3.1"
 description: Zeebe Helm Chart for Kubernetes
 name: zeebe
 type: application
-version: 1.3.4
+version: 0.0.1
 icon: https://helm.camunda.io/imgs/zeebe-logo.png
 annotations:
   artifacthub.io/changes: |

--- a/charts/ccsm-helm/charts/zeebe/templates/NOTES.txt
+++ b/charts/ccsm-helm/charts/zeebe/templates/NOTES.txt
@@ -7,12 +7,12 @@
 ({{ .Chart.Name }} - {{ .Chart.Version }})
 
 - Docker Image used for Broker: {{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}
-- Cluster Name: {{ tpl .Values.zeebeClusterName . | quote }}
+- Cluster Name: {{ tpl .Values.global.zeebeClusterName . | quote }}
 - Prometheus ServiceMonitor Enabled: {{ .Values.prometheusServiceMonitor.enabled }}
 
 The Cluster itself is not exposed as a service that means that you can use kubectl port-forward to access the Zeebe cluster from outside Kubernetes:
 
-> kubectl port-forward svc/{{ tpl .Values.zeebeClusterName . }}-gateway 26500:26500 -n {{ .Release.Namespace }}
+> kubectl port-forward svc/{{ tpl .Values.global.zeebeClusterName . }}-gateway 26500:26500 -n {{ .Release.Namespace }}
 
 Now you can connect your workers and clients to `localhost:26500`
 

--- a/charts/ccsm-helm/charts/zeebe/templates/_helpers.tpl
+++ b/charts/ccsm-helm/charts/zeebe/templates/_helpers.tpl
@@ -76,8 +76,8 @@ app.kubernetes.io/component: gateway
 Common names
 */}}
 {{- define "zeebe.names.broker" -}}
-{{- if .Values.zeebeClusterName -}}
-{{- tpl .Values.zeebeClusterName . | trunc 63 | trimSuffix "-" | quote -}}
+{{- if .Values.global.zeebeClusterName -}}
+{{- tpl .Values.global.zeebeClusterName . | trunc 63 | trimSuffix "-" | quote -}}
 {{- else -}}
 {{- printf "%s-broker" .Release.Name | trunc 63 | trimSuffix "-" | quote -}}
 {{- end -}}
@@ -87,7 +87,7 @@ Common names
 Creates a valid DNS name for the gateway
 */}}
 {{- define "zeebe.names.gateway" -}}
-{{- $name := default .Release.Name (tpl .Values.zeebeClusterName .) -}}
+{{- $name := default .Release.Name (tpl .Values.global.zeebeClusterName .) -}}
 {{- printf "%s-gateway" $name | trunc 63 | trimSuffix "-" | quote -}}
 {{- end -}}
 {{/*

--- a/charts/ccsm-helm/charts/zeebe/templates/gateway-deployment.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/gateway-deployment.yaml
@@ -47,7 +47,7 @@ spec:
             - name: ZEEBE_STANDALONE_GATEWAY
               value: "true"
             - name: ZEEBE_GATEWAY_CLUSTER_CLUSTERNAME
-              value: {{ tpl .Values.zeebeClusterName . }}
+              value: {{ tpl .Values.global.zeebeClusterName . }}
             - name: ZEEBE_GATEWAY_CLUSTER_MEMBERID
               valueFrom:
                 fieldRef:
@@ -57,7 +57,7 @@ spec:
             - name: JAVA_TOOL_OPTIONS
               value: {{ .Values.JavaOpts | quote }}
             - name: ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT
-              value: {{ tpl .Values.zeebeClusterName . }}:{{ .Values.service.internalPort }}
+              value: {{ tpl .Values.global.zeebeClusterName . }}:{{ .Values.service.internalPort }}
             - name: ZEEBE_GATEWAY_NETWORK_HOST
               value: 0.0.0.0
             - name: ZEEBE_GATEWAY_NETWORK_PORT

--- a/charts/ccsm-helm/charts/zeebe/templates/statefulset.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/statefulset.yaml
@@ -49,7 +49,7 @@ spec:
         - name: LC_ALL
           value: C.UTF-8
         - name: ZEEBE_BROKER_CLUSTER_CLUSTERNAME
-          value: {{ tpl .Values.zeebeClusterName . }}
+          value: {{ tpl .Values.global.zeebeClusterName . }}
         - name: ZEEBE_LOG_LEVEL
           value: {{ .Values.logLevel | quote }}
         - name: ZEEBE_BROKER_CLUSTER_PARTITIONSCOUNT

--- a/charts/ccsm-helm/charts/zeebe/templates/tests/test-connection.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/tests/test-connection.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ tpl .Values.zeebeClusterName . }}-test-connection"
+  name: "{{ tpl .Values.global.zeebeClusterName . }}-test-connection"
   labels:
 {{ include "zeebe.labels" . | indent 4 }}
   annotations:
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args:  ['{{ tpl .Values.zeebeClusterName . }}:{{ .Values.serviceHttpPort }}']
+      args:  ['{{ tpl .Values.global.zeebeClusterName . }}:{{ .Values.service.httpPort }}']
   restartPolicy: Never

--- a/charts/ccsm-helm/charts/zeebe/values.yaml
+++ b/charts/ccsm-helm/charts/zeebe/values.yaml
@@ -2,10 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# Annotations to apply to all deployments
-
-zeebeClusterName: "{{ .Release.Name }}-zeebe"
-
 #############
 # CONFIGS
 #############

--- a/charts/ccsm-helm/charts/zeebe/values.yaml
+++ b/charts/ccsm-helm/charts/zeebe/values.yaml
@@ -1,6 +1,10 @@
 # Default values for zeebe-helm.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+global:
+  image:
+    # global.image.repository overwrites the default repository to the operate image
+    repository: camunda/zeebe
 
 #############
 # CONFIGS

--- a/charts/ccsm-helm/templates/NOTES.txt
+++ b/charts/ccsm-helm/templates/NOTES.txt
@@ -1,0 +1,44 @@
+ ______     ______     __    __     __  __     __   __     _____     ______        ______     __         ______     __  __     _____
+/\  ___\   /\  __ \   /\ "-./  \   /\ \/\ \   /\ "-.\ \   /\  __-.  /\  __ \      /\  ___\   /\ \       /\  __ \   /\ \/\ \   /\  __-.
+\ \ \____  \ \  __ \  \ \ \-./\ \  \ \ \_\ \  \ \ \-.  \  \ \ \/\ \ \ \  __ \     \ \ \____  \ \ \____  \ \ \/\ \  \ \ \_\ \  \ \ \/\ \
+ \ \_____\  \ \_\ \_\  \ \_\ \ \_\  \ \_____\  \ \_\\"\_\  \ \____-  \ \_\ \_\     \ \_____\  \ \_____\  \ \_____\  \ \_____\  \ \____-
+  \/_____/   \/_/\/_/   \/_/  \/_/   \/_____/   \/_/ \/_/   \/____/   \/_/\/_/      \/_____/   \/_____/   \/_____/   \/_____/   \/____/
+
+({{ .Chart.Name }} - {{ .Chart.Version }})
+
+### Installed Services:
+
+- Zeebe:
+  - Docker Image used for Zeebe: {{ .Values.zeebe.global.image.repository }}:{{ .Values.global.image.tag }}
+  - Zeebe Cluster Name: {{ tpl .Values.global.zeebeClusterName . | quote }}
+  - Prometheus ServiceMonitor Enabled: {{ .Values.zeebe.prometheusServiceMonitor.enabled }}
+- Operate:
+  - Enabled: {{ .Values.operate.enabled }}
+  - Docker Image used for Operate: {{ .Values.operate.global.image.repository }}:{{ .Values.global.image.tag }}
+- Prometheus:
+  - Enabled: {{ .Values.prometheus.enabled }}
+- Elasticsearch:
+  - Enabled: {{ .Values.elasticsearch.enabled }}
+  - ElasticSearch URL: http://{{ .Values.global.elasticsearch.host }}:{{ .Values.global.elasticsearch.port }}
+- Kibana:
+  - Enabled: {{ .Values.kibana.enabled }}
+
+
+### Zeebe
+
+The Cluster itself is not exposed as a service that means that you can use `kubectl port-forward` to access the Zeebe cluster from outside Kubernetes:
+
+> kubectl port-forward svc/{{ tpl .Values.global.zeebeClusterName . }}-gateway 26500:26500 -n {{ .Release.Namespace }}
+
+Now you can connect your workers and clients to `localhost:26500`
+
+### Operate
+
+As part of the Operate HELM Chart an Ingress definition is deployed, but you require to have an Ingress Controller for that Ingress to be Exposed.
+If you don't have an Ingress Controller you can do kubectl port-forward to access Operate from outside the cluster:
+
+> kubectl port-forward svc/{{ include "zeebe-operate.fullname" . }} 8080:80
+
+Now you can point your browser to `http://localhost:8080`
+
+Default user and password: "demo/demo"

--- a/charts/ccsm-helm/values.yaml
+++ b/charts/ccsm-helm/values.yaml
@@ -1,11 +1,9 @@
-# Default values for ccsm-helm.
+# Default values for Camunda Cloud Self Managed helm.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# Annotations to apply to all deployments
-
-
 global:
+  # Annotations to apply to all deployments
   annotations: {}
   labels:
     app: camunda-cloud-self-managed
@@ -19,7 +17,7 @@ global:
     url:
     host: "elasticsearch-master"
     port: 9200
-  ccsm: "{{ .Release.Name }}-ccsm"
+  zeebeClusterName: "{{ .Release.Name }}-zeebe"
 
 zeebe:
   enabled: true

--- a/charts/ccsm-helm/values.yaml
+++ b/charts/ccsm-helm/values.yaml
@@ -32,6 +32,9 @@ operate:
 elasticsearch:
   enabled: true
   imageTag: 7.16.2
+  extraEnvs:
+    - name: "xpack.security.enabled"
+      value: "false"
 
 kibana:
   enabled: false

--- a/charts/ccsm-helm/values.yaml
+++ b/charts/ccsm-helm/values.yaml
@@ -8,7 +8,8 @@ global:
   labels:
     app: camunda-cloud-self-managed
   image:
-    repository: camunda/zeebe
+    # global.image.repository is net set here, otherwise it will overwrite the values from the sub chart
+    #    repository: camunda/zeebe
     tag: 1.3.1
     pullPolicy: IfNotPresent
     pullSecrets: [ ]
@@ -17,9 +18,15 @@ global:
     url:
     host: "elasticsearch-master"
     port: 9200
+    clusterName: "elasticsearch"
+    prefix: zeebe-record
   zeebeClusterName: "{{ .Release.Name }}-zeebe"
+  zeebePort: 26500
 
 zeebe:
+  enabled: true
+
+operate:
   enabled: true
 
 elasticsearch:


### PR DESCRIPTION
 * Copies the old zeebe-operate-helm chart into the ccsm chart.
 * Renames the chart to operate instead of zeebe-operate-helm
 * Fixes some properties in zeebe and operate charts, in regards to the new sub chart
 * Fix an elastic issue (disable security to omit warning)
 * Create new NOTEST.txt for the ccsm helm - this file shows after installation what has been installed and how to use it
 * Tested manually, via deploying into kubernetes, starting some instances and verifying in operate
 * increase ccsm chart version

related to #124 

Missing: 
 * Readme update
 * Values file documentation