### PR TITLE
Disable ingress per default

### DIFF
--- a/charts/ccsm-helm/values.yaml
+++ b/charts/ccsm-helm/values.yaml
@@ -281,7 +281,7 @@ operate:
   # Ingress configuration to configure the ingress resource
   ingress:
     # Ingress.enabled if true, an ingress resource is deployed with the operate deployment. Only useful if an ingress controller is available, like nginx.
-    enabled: true
+    enabled: false
     # Ingress.className defines the class or configuration of ingress which should be used by the controller
     className: nginx
     # Ingress.annotations defines the ingress related annotations, consumed mostly by the ingress controller
@@ -337,7 +337,7 @@ tasklist:
   # Ingress configuration to configure the ingress resource
   ingress:
     # Ingress.enabled if true, an ingress resource is deployed with the tasklist deployment. Only useful if an ingress controller is available, like nginx.
-    enabled: true
+    enabled: false
     # Ingress.className defines the class or configuration of ingress which should be used by the controller
     className: nginx
     # Ingress.annotations defines the ingress related annotations, consumed mostly by the ingress controller


### PR DESCRIPTION
Deploying ingress resource per default doesn't make much sense, since not everyone has an ingress controller deployed. We decided to disable it per default. 

Like its done in other charts:

Grafana
https://github.com/grafana/helm-charts/blob/main/charts/grafana/values.yaml#L183-L184

Kibana:
https://github.com/elastic/helm-charts/blob/main/kibana/values.yaml#L142-L143

Elasticsearch
https://github.com/elastic/helm-charts/blob/main/elasticsearch/values.yaml#L250-L251


BTW @menski I saw that the previous full chart deployed an ingress nginx controller https://github.com/camunda-community-hub/camunda-cloud-helm/blob/main/charts/zeebe-full-helm/Chart.yaml#L19-L21 but tbh I'm not sure whether we really want that.