### PR TITLE
Rework config map's

### DIFF
--- a/charts/ccsm-helm/charts/zeebe-gateway/templates/configmap.yaml
+++ b/charts/ccsm-helm/charts/zeebe-gateway/templates/configmap.yaml
@@ -4,36 +4,6 @@ metadata:
   labels: {{- include "zeebe.labels.gateway" . | nindent 4 }}
 apiVersion: v1
 data:
-  startup.sh: |
-    #!/usr/bin/env bash
-    set -eux -o pipefail
-
-    export ZEEBE_BROKER_NETWORK_ADVERTISEDHOST=${ZEEBE_BROKER_NETWORK_ADVERTISEDHOST:-$(hostname -f)}
-    export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-${K8S_POD_NAME##*-}}
-
-    # As the number of replicas or the DNS is not obtainable from the downward API yet,
-    # defined them here based on conventions
-    export ZEEBE_BROKER_CLUSTER_CLUSTERSIZE=${ZEEBE_BROKER_CLUSTER_CLUSTERSIZE:-1}
-    contactPointPrefix=${K8S_POD_NAME%-*}
-    contactPoints=${ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS:-""}
-    if [[ -z "${contactPoints}" ]]; then
-      for ((i=0; i<${ZEEBE_BROKER_CLUSTER_CLUSTERSIZE}; i++))
-      do
-        contactPoints="${contactPoints},${contactPointPrefix}-$i.$(hostname -d):{{ .Values.service.internalPort }}"
-      done
-
-      export ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS="${contactPoints}"
-    fi
-    
-    if [ "$(ls -A /exporters/)" ]; then
-      mkdir /usr/local/zeebe/exporters/
-      cp -a /exporters/*.jar /usr/local/zeebe/exporters/
-    else  
-      echo "No exporters available."
-    fi
-
-    exec /usr/local/zeebe/bin/broker
-
   gateway-log4j2.xml: |
 {{- if .Values.log4j2 }}
     {{ .Values.log4j2 | indent 4 | trim }}

--- a/charts/ccsm-helm/charts/zeebe/templates/configmap.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/configmap.yaml
@@ -8,30 +8,16 @@ data:
     #!/usr/bin/env bash
     set -eux -o pipefail
 
-    export ZEEBE_BROKER_NETWORK_ADVERTISEDHOST=${ZEEBE_BROKER_NETWORK_ADVERTISEDHOST:-$(hostname -f)}
-    export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-${K8S_POD_NAME##*-}}
+    export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-${K8S_NAME##*-}}
 
-    # As the number of replicas or the DNS is not obtainable from the downward API yet,
-    # defined them here based on conventions
-    export ZEEBE_BROKER_CLUSTER_CLUSTERSIZE=${ZEEBE_BROKER_CLUSTER_CLUSTERSIZE:-1}
-    contactPointPrefix=${K8S_POD_NAME%-*}
-    contactPoints=${ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS:-""}
-    if [[ -z "${contactPoints}" ]]; then
-      for ((i=0; i<${ZEEBE_BROKER_CLUSTER_CLUSTERSIZE}; i++))
-      do
-        contactPoints="${contactPoints},${contactPointPrefix}-$i.$(hostname -d):{{ .Values.service.internalPort }}"
-      done
-
-      export ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS="${contactPoints}"
-    fi
-    
     if [ "$(ls -A /exporters/)" ]; then
       mkdir /usr/local/zeebe/exporters/
       cp -a /exporters/*.jar /usr/local/zeebe/exporters/
-    else  
+    else
       echo "No exporters available."
     fi
 
+    env
     exec /usr/local/zeebe/bin/broker
 
   application.yaml: |

--- a/charts/ccsm-helm/charts/zeebe/templates/statefulset.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/statefulset.yaml
@@ -46,6 +46,23 @@ spec:
         env:
         - name: LC_ALL
           value: C.UTF-8
+        - name: K8S_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: K8S_SERVICE_NAME
+          value: {{ include "zeebe.names.broker" . }}
+        - name: K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: ZEEBE_BROKER_NETWORK_ADVERTISEDHOST
+          value: "$(K8S_NAME).$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc.cluster.local"
+        - name: ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS
+          value:
+          {{- range (untilStep 0 (int .Values.clusterSize) 1) }}
+            $(K8S_SERVICE_NAME)-{{ . }}.$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc.cluster.local,
+          {{- end }}
         - name: ZEEBE_BROKER_CLUSTER_CLUSTERNAME
           value: {{ tpl .Values.global.zeebeClusterName . }}
         - name: ZEEBE_LOG_LEVEL


### PR DESCRIPTION
Reworks the zeebe config maps which are deployed with the services/applications.

 * Remove the startup scripts from the gateway config map
 * Replace most of the code from the zeebe startup script with kubernetes [dependent environment variables ](https://kubernetes.io/docs/tasks/inject-data-application/define-interdependent-environment-variables/)
   * inspired by https://github.com/camunda-community-hub/camunda-cloud-operator/blob/main/operator/controllers/zeebe_controller.go 
   * **Why:** To have everything in one place and for better maintainability most of the env vars are set in the statefulset manifest. 
 * Initial contact points are calculated with helm template range (inspired by https://github.com/helm/helm/issues/1055)



I tried it out and the following is calculated correctly:
```
$ k logs test-zeebe-0

+ env
...
ZEEBE_BROKER_CLUSTER_NODEID=0
ZEEBE_BROKER_CLUSTER_CLUSTERNAME=test-zeebe
ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS=test-zeebe-0.test-zeebe.zell-helm-test.svc.cluster.local, test-zeebe-1.test-zeebe.zell-helm-test.svc.cluster.local, test-zeebe-2.test-zeebe.zell-helm-test.svc.cluster.local,
...
K8S_NAMESPACE=zell-helm-test
K8S_SERVICE_NAME=test-zeebe
K8S_NAME=test-zeebe-0

```

\cc Maybe interesting for you @Sijoma (I can still not request a review from you)

related to #124 