### PR TITLE
refactor: remove unused configmap

### DIFF
--- a/charts/ccsm-helm/charts/zeebe/templates/configmap.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/configmap.yaml
@@ -20,13 +20,6 @@ data:
     env
     exec /usr/local/zeebe/bin/broker
 
-  application.yaml: |
-{{- if .Values.zeebeCfg }}
-{{- with .Values.zeebeCfg }}
-{{ . | toYaml | indent 4 }}
-{{- end }}
-{{- end }}
-
   broker-log4j2.xml: |
 {{- if .Values.log4j2 }}
     {{ .Values.log4j2 | indent 4 | trim }}


### PR DESCRIPTION
The configmap was unused and make the configuration not really easy. All zeebe configurations can be done via env vars.