### PR TITLE
fix: use correct labels

### DIFF
--- a/charts/ccsm-helm/charts/zeebe/templates/service-monitor.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/service-monitor.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "zeebe.labels" . | nindent 6 }}
+      {{- include "zeebe.labels.broker" . | nindent 6 }}
   endpoints:
     - honorLabels: true
       port: http


### PR DESCRIPTION
Service monitor uses the wrong template for label selector 