### PR TITLE
Add retention policy

### DIFF
--- a/charts/ccsm-helm/README.md
+++ b/charts/ccsm-helm/README.md
@@ -68,6 +68,18 @@ Check out the default [values.yaml](values.yaml) file, which contains the same c
 | `prometheus`| `enabled` | Enable Prometheus operator as part of the Zeebe Cluster | `false` |
 | | `servicemonitor.enabled` | Deploy a `ServiceMonitor` for your Zeebe Cluster | `false` |
 
+### CCSM
+
+| Section | Parameter | Description | Default |
+|-|-|-|-|
+| `retentionPolicy` | | Configuration to configure the elasticsearch index retention policies | |
+| | `enabled` | If true, elasticsearch curator cronjob and configuration will be deployed. | `false` |
+| | `schedule` | Defines how often/when the curator should run. | `"0 0 * * *"` |
+| | `zeebeIndexTTL` | Defines after how many days a zeebe index can be deleted. | `1` |
+| | `zeebeIndexMaxSize` | Can be set to configure the maximum allowed zeebe index size in gigabytes. After reaching that size, curator will delete that corresponding index on the next run. To benefit from that configuration the schedule needs to be configured small enough, like every 15 minutes. | `` |
+| | `operateIndexTTL` | Defines after how many days an operate index can be deleted. | `30` |
+| | `tasklistIndexTTL` | Defines after how many days an tasklist index can be deleted. | `30` |
+
 ### Zeebe
 
 Information about Zeebe you can find [here](https://docs.camunda.io/docs/components/zeebe/zeebe-overview/).

--- a/charts/ccsm-helm/templates/curator-configmap.yaml
+++ b/charts/ccsm-helm/templates/curator-configmap.yaml
@@ -1,0 +1,128 @@
+{{- if .Values.retentionPolicy.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ccsm-curator-config
+  labels:
+    {{- include "ccsm.labels" . | nindent 4 }}
+data:
+  action_file.yml: |-
+    ---
+    # Remember, leave a key empty if there is no value.  None will be a string,
+    # not a Python "NoneType"
+    #
+    # Also remember that all examples have 'disable_action' set to True.  If you
+    # want to use this action as a template, be sure to set this to False after
+    # copying it.
+    actions:
+      # delete zeebe- indicies
+      1:
+        action: delete_indices
+        description: "Clean up ES by deleting old Zeebe indices"
+        options:
+          timeout_override:
+          continue_if_exception: False
+          disable_action: False
+          ignore_empty_list: True
+        filters:
+          - filtertype: pattern
+            kind: prefix
+            value: zeebe-
+          - filtertype: age
+            source: name
+            direction: older
+            timestring: '%Y-%m-%d'
+            unit: days
+            unit_count: {{ .Values.retentionPolicy.zeebeIndexTTL }}
+            field:
+            stats_result:
+            epoch:
+            exclude: False
+      # delete operate- indicies
+      2:
+        action: delete_indices
+        description: "Clean up ES by deleting old Operate indices"
+        options:
+          timeout_override:
+          continue_if_exception: False
+          disable_action: False
+          ignore_empty_list: True
+        filters:
+          - filtertype: pattern
+            kind: prefix
+            value: operate-
+          - filtertype: age
+            source: name
+            direction: older
+            timestring: '%Y-%m-%d'
+            unit: days
+            unit_count: {{ .Values.retentionPolicy.operateIndexTTL }}
+            field:
+            stats_result:
+            epoch:
+            exclude: False
+      # delete tasklist- indicies
+      3:
+        action: delete_indices
+        description: "Clean up ES by deleting old Tasklist indices"
+        options:
+          timeout_override:
+          continue_if_exception: False
+          disable_action: False
+          ignore_empty_list: True
+        filters:
+          - filtertype: pattern
+            kind: prefix
+            value: tasklist-
+          - filtertype: age
+            source: name
+            direction: older
+            timestring: '%Y-%m-%d'
+            unit: days
+            unit_count: {{ .Values.retentionPolicy.tasklistIndexTTL }}
+            field:
+            stats_result:
+            epoch:
+            exclude: False
+      # or delete indicies which exceed the total size of 10 gig
+    {{- if .Values.retentionPolicy.zeebeIndexMaxSize }}
+      4:
+        action: delete_indices
+        description: "Clean up ES by deleting too big Zeebe indices"
+        options:
+          timeout_override:
+          continue_if_exception: False
+          disable_action: False
+          ignore_empty_list: True
+        filters:
+          - filtertype: pattern
+            kind: prefix
+            value: zeebe-
+          - filtertype: space
+            disk_space: {{ .Values.retentionPolicy.zeebeIndexMaxSize }}
+            source: name
+            timestring: '%Y-%m-%d'
+    {{- end }}
+  config.yml: |-
+    ---
+    # Remember, leave a key empty if there is no value.  None will be a string,
+    # not a Python "NoneType"
+    client:
+      hosts:
+        - elasticsearch-master-headless
+      port: 9200
+      url_prefix:
+      use_ssl: False
+      certificate:
+      client_cert:
+      client_key:
+      ssl_no_validate: False
+      http_auth:
+      timeout: 30
+      master_only: False
+    logging:
+      loglevel: INFO
+      logfile:
+      logformat: default
+      blacklist: ['elasticsearch', 'urllib3']
+{{- end }}

--- a/charts/ccsm-helm/templates/curator-configmap.yaml
+++ b/charts/ccsm-helm/templates/curator-configmap.yaml
@@ -15,7 +15,7 @@ data:
     # want to use this action as a template, be sure to set this to False after
     # copying it.
     actions:
-      # delete zeebe- indicies
+      # delete zeebe- indices
       1:
         action: delete_indices
         description: "Clean up ES by deleting old Zeebe indices"
@@ -38,7 +38,7 @@ data:
             stats_result:
             epoch:
             exclude: False
-      # delete operate- indicies
+      # delete operate- indices
       2:
         action: delete_indices
         description: "Clean up ES by deleting old Operate indices"
@@ -61,7 +61,7 @@ data:
             stats_result:
             epoch:
             exclude: False
-      # delete tasklist- indicies
+      # delete tasklist- indices
       3:
         action: delete_indices
         description: "Clean up ES by deleting old Tasklist indices"
@@ -84,7 +84,7 @@ data:
             stats_result:
             epoch:
             exclude: False
-      # or delete indicies which exceed the total size of 10 gig
+      # or delete indices which exceed the total size of 10 gig
     {{- if .Values.retentionPolicy.zeebeIndexMaxSize }}
       4:
         action: delete_indices

--- a/charts/ccsm-helm/templates/curator-cronjob.yaml
+++ b/charts/ccsm-helm/templates/curator-cronjob.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.retentionPolicy.enabled -}}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: ccsm-curator
+  labels:
+    {{- include "ccsm.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.retentionPolicy.schedule | quote }}
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 120
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - image: bobrik/curator:5.7.6
+              name: curator
+              args: ["--config", "/etc/config/config.yml", "/etc/config/action_file.yml"]
+              volumeMounts:
+                - name: config
+                  mountPath: /etc/config
+          volumes:
+            - name: config
+              configMap:
+                name: curator-config
+          restartPolicy: OnFailure
+{{- end }}

--- a/charts/ccsm-helm/templates/curator-cronjob.yaml
+++ b/charts/ccsm-helm/templates/curator-cronjob.yaml
@@ -16,7 +16,7 @@ spec:
       template:
         spec:
           containers:
-            - image: bobrik/curator:5.7.6
+            - image: bitnami/elasticsearch-curator:5.8.4
               name: curator
               args: ["--config", "/etc/config/config.yml", "/etc/config/action_file.yml"]
               volumeMounts:

--- a/charts/ccsm-helm/values.yaml
+++ b/charts/ccsm-helm/values.yaml
@@ -369,6 +369,23 @@ tasklist:
     # If not specified the rules applies to all inbound http traffic, if specified the rule applies to that host.
     host:
 
+# RetentionPolicy configuration to configure the elasticsearch index retention policies
+retentionPolicy:
+  # RetentionPolicy.enabled if true, elasticsearch curator cronjob will be deployed
+  enabled: false
+  # RetentionPolicy.schedule defines how often/when the curator should run
+  schedule: "0 0 * * *"
+  # RetentionPolicy.zeebeIndexTTL defines after how many days a zeebe index can be deleted
+  zeebeIndexTTL: 1
+  # RetentionPolicy.zeebeIndexMaxSize can be set to configure the maximum allowed zeebe index size in gigabytes.
+  # After reaching that size, curator will delete that corresponding index on the next run.
+  # To benefit from that configuration the schedule needs to be configured small enough, like every 15 minutes.
+  zeebeIndexMaxSize:
+  # RetentionPolicy.operateIndexTTL defines after how many days an Operate index can be deleted
+  operateIndexTTL: 30
+  # RetentionPolicy.tasklistIndexTTL defines after how many days a tasklist index can be deleted
+  tasklistIndexTTL: 30
+
 elasticsearch:
   enabled: true
   imageTag: 7.16.2

--- a/charts/ccsm-helm/values.yaml
+++ b/charts/ccsm-helm/values.yaml
@@ -371,7 +371,7 @@ tasklist:
 
 # RetentionPolicy configuration to configure the elasticsearch index retention policies
 retentionPolicy:
-  # RetentionPolicy.enabled if true, elasticsearch curator cronjob will be deployed
+  # RetentionPolicy.enabled if true, elasticsearch curator cronjob and configuration will be deployed.
   enabled: false
   # RetentionPolicy.schedule defines how often/when the curator should run
   schedule: "0 0 * * *"
@@ -381,7 +381,7 @@ retentionPolicy:
   # After reaching that size, curator will delete that corresponding index on the next run.
   # To benefit from that configuration the schedule needs to be configured small enough, like every 15 minutes.
   zeebeIndexMaxSize:
-  # RetentionPolicy.operateIndexTTL defines after how many days an Operate index can be deleted
+  # RetentionPolicy.operateIndexTTL defines after how many days an operate index can be deleted
   operateIndexTTL: 30
   # RetentionPolicy.tasklistIndexTTL defines after how many days a tasklist index can be deleted
   tasklistIndexTTL: 30


### PR DESCRIPTION
 

 * Adds curator templates for cronjob and configmap.
 * Disabled by default
 * Zeebe index can be deleted by time
 * Tasklist index can be deleted by time
 * Operate index can be deleted by time
 * Zeebe indexes can be deleted by size (have to be enabled separately, useful for our benchmarks)

Everything can be configured by the following values:

```yaml
    # RetentionPolicy configuration to configure the elasticsearch index retention policies
    retentionPolicy:
      # RetentionPolicy.enabled if true, elasticsearch curator cronjob will be deployed
      enabled: false
      # RetentionPolicy.schedule defines how often/when the curator should run
      schedule: "0 0 * * *"
      # RetentionPolicy.zeebeIndexTTL defines after how many days a zeebe index can be deleted
      zeebeIndexTTL: 1
      # RetentionPolicy.zeebeIndexMaxSize can be set to configure the maximum allowed zeebe index size in gigabytes.
      # After reaching that size, curator will delete that corresponding index on the next run.
      # To benefit from that configuration the schedule needs to be configured small enough, like every 15 minutes.
      zeebeIndexMaxSize:
      # RetentionPolicy.operateIndexTTL defines after how many days an Operate index can be deleted
      operateIndexTTL: 30
      # RetentionPolicy.tasklistIndexTTL defines after how many days a tasklist index can be deleted
      tasklistIndexTTL: 30

```


Tested via `helm install --dry-run test . --set retentionPolicy.enabled=true --set retentionPolicy.zeebeIndexMaxSize=10`


Output:

```yaml
---
# Source: ccsm-helm/templates/curator-configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: ccsm-curator-config
  labels:
    app: camunda-cloud-self-managed
    app.kubernetes.io/name: ccsm-helm
    helm.sh/chart: ccsm-helm-0.0.10
    app.kubernetes.io/instance: test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/version: 1.3.1
    app.kubernetes.io/part-of: camunda-cloud-self-managed
data:
  action_file.yml: |-
    ---
    # Remember, leave a key empty if there is no value.  None will be a string,
    # not a Python "NoneType"
    #
    # Also remember that all examples have 'disable_action' set to True.  If you
    # want to use this action as a template, be sure to set this to False after
    # copying it.
    actions:
      # delete zeebe- indicies
      1:
        action: delete_indices
        description: "Clean up ES by deleting old Zeebe indices"
        options:
          timeout_override:
          continue_if_exception: False
          disable_action: False
          ignore_empty_list: True
        filters:
          - filtertype: pattern
            kind: prefix
            value: zeebe-
          - filtertype: age
            source: name
            direction: older
            timestring: '%Y-%m-%d'
            unit: days
            unit_count: 1
            field:
            stats_result:
            epoch:
            exclude: False
      # delete operate- indicies
      2:
        action: delete_indices
        description: "Clean up ES by deleting old Operate indices"
        options:
          timeout_override:
          continue_if_exception: False
          disable_action: False
          ignore_empty_list: True
        filters:
          - filtertype: pattern
            kind: prefix
            value: operate-
          - filtertype: age
            source: name
            direction: older
            timestring: '%Y-%m-%d'
            unit: days
            unit_count: 30
            field:
            stats_result:
            epoch:
            exclude: False
      # delete tasklist- indicies
      3:
        action: delete_indices
        description: "Clean up ES by deleting old Tasklist indices"
        options:
          timeout_override:
          continue_if_exception: False
          disable_action: False
          ignore_empty_list: True
        filters:
          - filtertype: pattern
            kind: prefix
            value: tasklist-
          - filtertype: age
            source: name
            direction: older
            timestring: '%Y-%m-%d'
            unit: days
            unit_count: 30
            field:
            stats_result:
            epoch:
            exclude: False
      # or delete indicies which exceed the total size of 10 gig
      4:
        action: delete_indices
        description: "Clean up ES by deleting too big Zeebe indices"
        options:
          timeout_override:
          continue_if_exception: False
          disable_action: False
          ignore_empty_list: True
        filters:
          - filtertype: pattern
            kind: prefix
            value: zeebe-
          - filtertype: space
            disk_space: 10
            source: name
            timestring: '%Y-%m-%d'
  config.yml: |-
    ---
    # Remember, leave a key empty if there is no value.  None will be a string,
    # not a Python "NoneType"
    client:
      hosts:
        - elasticsearch-master-headless
      port: 9200
      url_prefix:
      use_ssl: False
      certificate:
      client_cert:
      client_key:
      ssl_no_validate: False
      http_auth:
      timeout: 30
      master_only: False
    logging:
      loglevel: INFO
      logfile:
      logformat: default
      blacklist: ['elasticsearch', 'urllib3']
# Source: ccsm-helm/templates/curator-cronjob.yaml
apiVersion: batch/v1beta1
kind: CronJob
metadata:
  name: ccsm-curator
  labels:
    app: camunda-cloud-self-managed
    app.kubernetes.io/name: ccsm-helm
    helm.sh/chart: ccsm-helm-0.0.10
    app.kubernetes.io/instance: test
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/version: 1.3.1
    app.kubernetes.io/part-of: camunda-cloud-self-managed
spec:
  schedule: "0 0 * * *"
  successfulJobsHistoryLimit: 1
  failedJobsHistoryLimit: 3
  concurrencyPolicy: Forbid
  startingDeadlineSeconds: 120
  jobTemplate:
    spec:
      template:
        spec:
          containers:
            - image: bobrik/curator:5.7.6
              name: curator
              args: ["--config", "/etc/config/config.yml", "/etc/config/action_file.yml"]
              volumeMounts:
                - name: config
                  mountPath: /etc/config
          volumes:
            - name: config
              configMap:
                name: curator-config
          restartPolicy: OnFailure

```

closes https://github.com/camunda-community-hub/camunda-cloud-helm/issues/159
closes #128 