### PR TITLE
Add possibility to overwrite images correctly

### DIFF
--- a/charts/ccsm-helm/README.md
+++ b/charts/ccsm-helm/README.md
@@ -75,6 +75,9 @@ Information about Zeebe you can find [here](https://docs.camunda.io/docs/compone
 | Section | Parameter | Description | Default |
 |-|-|-|-|
 | `zeebe` | Configuration for the Zeebe sub chart. Contains configuration for the Zeebe broker and related resources. | |
+| | `image` | Configuration to configure the Zeebe image specifics. | |
+| | `image.repository` | Defines which image repository to use. | `camunda/zeebe` |
+| | `image.tag` | Can be set to overwrite the global tag, which should be used in that chart. | `` |
 | | `clusterSize` | Defines the amount of brokers (=replicas), which are deployed via helm | `3` |
 | | `partitionCount` | Defines how many Zeebe partitions are set up in the cluster | `3` |
 | | `replicationFactor` | Defines how each partition is replicated, the value defines the number of nodes | `3` |
@@ -127,6 +130,9 @@ Information about the Zeebe Gateway you can find [here](https://docs.camunda.io/
 |-|-|-|-|
 | `zeebe-gateway`| | Configuration to define properties related to the Zeebe standalone gateway | |
 | | `replicas` | Defines how many standalone gateways are deployed | `1` |
+| | `image` | Configuration to configure the zeebe-gateway image specifics. | |
+| | `image.repository` | Defines which image repository to use. | `camunda/zeebe` |
+| | `image.tag` | Can be set to overwrite the global tag, which should be used in that chart. | `` |
 | | `podAnnotations` | Can be used to define extra gateway pod annotations | `{ }` |
 | | `podLabels` | Can be used to define extra gateway pod labels | `{ }` |
 | | `annotations` | Can be used to define gateway deployment annotations | `{ } `|
@@ -166,6 +172,9 @@ Information about Operate you can find [here](https://docs.camunda.io/docs/compo
 |-|-|-|-|
 | `operate` | | Configuration for the Operate sub chart. | |
 | | `enabled` | If true, the Operate deployment and its related resources are deployed via a helm release | `true` |
+| | `image` | Configuration to configure the operate image specifics. | |
+| | `image.repository` | Defines which image repository to use. | `camunda/operate` |
+| | `image.tag` | Can be set to overwrite the global tag, which should be used in that chart. | `` |
 | | `logging` | Configuration for the Operate logging. This template will be directly included in the Operate configuration yaml file | `level:` <br/> `ROOT: INFO` <br/> `org.camunda.operate: DEBUG` |
 | | `service` | Configuration to configure the Operate service. | |
 | | `service.type` | Defines the [type of the service](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) | `ClusterIP` |
@@ -197,6 +206,9 @@ Information about Tasklist you can find [here](https://docs.camunda.io/docs/comp
 |-|-|-|-|
 | | `tasklist` | Configuration for the Tasklist sub chart. | |
 | | `enabled` | If true, the Tasklist deployment and its related resources are deployed via a helm release | `true` |
+| | `image` | Configuration to configure the tasklist image specifics. | |
+| | `image.repository` | Defines which image repository to use. | `camunda/tasklist` |
+| | `image.tag` | Can be set to overwrite the global tag, which should be used in that chart. | `` |
 | | `service` | Configuration to configure the Tasklist service. | |
 | | `service.type` | Defines the [type of the service](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) | `ClusterIP` |
 | | `service.port` | Defines the port of the service, where the Tasklist web application will be available | `80` |

--- a/charts/ccsm-helm/charts/operate/templates/deployment.yaml
+++ b/charts/ccsm-helm/charts/operate/templates/deployment.yaml
@@ -17,7 +17,11 @@ spec:
     spec:
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}"
+        {{- if .Values.image.tag }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- else -}}
+        image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
+        {{- end }}
         {{- if .Values.env}}
         env:
         {{ .Values.env | toYaml | nindent 10 }}

--- a/charts/ccsm-helm/charts/operate/templates/deployment.yaml
+++ b/charts/ccsm-helm/charts/operate/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       - name: {{ .Chart.Name }}
         {{- if .Values.image.tag }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        {{- else -}}
+        {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
         {{- end }}
         {{- if .Values.env}}

--- a/charts/ccsm-helm/charts/operate/values.yaml
+++ b/charts/ccsm-helm/charts/operate/values.yaml
@@ -1,4 +1,0 @@
-global:
-  image:
-    # global.image.repository overwrites the default repository to the operate image
-    repository: camunda/operate

--- a/charts/ccsm-helm/charts/tasklist/templates/deployment.yaml
+++ b/charts/ccsm-helm/charts/tasklist/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       - name: {{ .Chart.Name }}
         {{- if .Values.image.tag }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        {{- else -}}
+        {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
         {{- end }}
         env:

--- a/charts/ccsm-helm/charts/tasklist/templates/deployment.yaml
+++ b/charts/ccsm-helm/charts/tasklist/templates/deployment.yaml
@@ -14,7 +14,11 @@ spec:
     spec:
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}"
+        {{- if .Values.image.tag }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- else -}}
+        image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
+        {{- end }}
         env:
           - name: SPRING_PROFILES_ACTIVE
             value: {{ default "auth" .Values.springProfilesActive | quote }}

--- a/charts/ccsm-helm/charts/tasklist/values.yaml
+++ b/charts/ccsm-helm/charts/tasklist/values.yaml
@@ -1,4 +1,0 @@
-global:
-  image:
-    # global.image.repository overwrites the default repository to the operate image
-    repository: camunda/tasklist

--- a/charts/ccsm-helm/charts/zeebe-gateway/templates/gateway-deployment.yaml
+++ b/charts/ccsm-helm/charts/zeebe-gateway/templates/gateway-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: {{ .Chart.Name }}
           {{- if .Values.image.tag }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          {{- else -}}
+          {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
           {{- end }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}

--- a/charts/ccsm-helm/charts/zeebe-gateway/templates/gateway-deployment.yaml
+++ b/charts/ccsm-helm/charts/zeebe-gateway/templates/gateway-deployment.yaml
@@ -33,7 +33,11 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}"
+          {{- if .Values.image.tag }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          {{- else -}}
+          image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
           ports:
             - containerPort: {{  .Values.service.httpPort }}

--- a/charts/ccsm-helm/charts/zeebe/templates/statefulset.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/statefulset.yaml
@@ -43,7 +43,7 @@ spec:
       - name: {{ .Chart.Name }}
         {{- if .Values.image.tag }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        {{- else -}}
+        {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
         {{- end }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}

--- a/charts/ccsm-helm/charts/zeebe/templates/statefulset.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/statefulset.yaml
@@ -41,7 +41,11 @@ spec:
         {{- end }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}"
+        {{- if .Values.image.tag }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- else -}}
+        image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
         env:
         - name: LC_ALL

--- a/charts/ccsm-helm/values.yaml
+++ b/charts/ccsm-helm/values.yaml
@@ -33,9 +33,6 @@ global:
 
   # Image configuration to be used in each sub chart
   image:
-    # global.image.repository is net set here, otherwise it will overwrite the values from the sub chart
-    #    repository: camunda/zeebe
-
     # Image.tag defines the tag / version which should be used in the chart
     tag: 1.3.1
     # Image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
@@ -66,6 +63,13 @@ global:
 zeebe:
   # Enabled if true, all zeebe related resources are deployed via the helm release
   enabled: true
+
+  # Image configuration to configure the zeebe image specifics
+  image:
+    # Image.repository defines which image repository to use
+    repository: camunda/zeebe
+    # Image.tag can be set to overwrite the global tag, which should be used in that chart
+    tag:
 
   # ClusterSize defines the amount of brokers (=replicas), which are deployed via helm
   clusterSize: "3"
@@ -184,6 +188,12 @@ zeebe:
 zeebe-gateway:
   # Replicas defines how many standalone gateways are deployed
   replicas: 1
+  # Image configuration to configure the zeebe-gateway image specifics
+  image:
+    # Image.repository defines which image repository to use
+    repository: camunda/zeebe
+    # Image.tag can be set to overwrite the global tag, which should be used in that chart
+    tag:
   # PodAnnotations can be used to define extra gateway pod annotations
   podAnnotations: { }
   # PodLabels can be used to define extra gateway pod labels
@@ -259,6 +269,13 @@ operate:
   # Enabled if true, the operate deployment and its related resources are deployed via a helm release
   enabled: true
 
+  # Image configuration to configure the operate image specifics
+  image:
+    # Image.repository defines which image repository to use
+    repository: camunda/operate
+    # Image.tag can be set to overwrite the global tag, which should be used in that chart
+    tag:
+
   # Logging configuration for the operate logging. This template will be directly included in the operate configuration yaml file
   logging:
     level:
@@ -326,6 +343,13 @@ operate:
 tasklist:
   # Enabled if true, the tasklist deployment and its related resources are deployed via a helm release
   enabled: true
+
+  # Image configuration to configure the tasklist image specifics
+  image:
+    # Image.repository defines which image repository to use
+    repository: camunda/tasklist
+    # Image.tag can be set to overwrite the global tag, which should be used in that chart
+    tag:
 
   # Service configuration to configure the tasklist service.
   service:


### PR DESCRIPTION
Previously the subcharts reused a global variables which caused issues on setting different image repositories. For each subchart now an own image.repository variable is used. The global tag is still possible, use case to set a version only once. But it is possible to overwrite the global setting with a subchart specific image tag.

So it would be possible to use a different operate version than zeebe version, if necessary.

fixes https://github.com/camunda-community-hub/camunda-cloud-helm/issues/161