### PR TITLE
Hide services details if disabled

### DIFF
--- a/charts/ccsm-helm/templates/NOTES.txt
+++ b/charts/ccsm-helm/templates/NOTES.txt
@@ -33,6 +33,7 @@ The Cluster itself is not exposed as a service that means that you can use `kube
 > kubectl port-forward svc/{{ tpl .Values.global.zeebeClusterName . }}-gateway 26500:26500 -n {{ .Release.Namespace }}
 
 Now you can connect your workers and clients to `localhost:26500`
+{{- if .Values.operate.enabled }}
 
 ### Operate
 
@@ -44,6 +45,8 @@ If you don't have an Ingress Controller you can do kubectl port-forward to acces
 Now you can point your browser to `http://localhost:8080`
 
 Default user and password: "demo/demo"
+{{- end }}
+{{- if .Values.tasklist.enabled }}
 
 ### Tasklist
 
@@ -55,3 +58,4 @@ If you don't have an Ingress Controller you can do kubectl port-forward to acces
 Now you can point your browser to `http://localhost:8080`
 
 Default user and password: "demo/demo"
+{{- end }}


### PR DESCRIPTION
Takslist and Operate should not be part of the release notes if not enabled, this PR adds a extra condition to the notes template to hide it them.

When enabled (default):
```
NOTES:
______     ______     __    __     __  __     __   __     _____     ______        ______     __         ______     __  __     _____
/\  ___\   /\  __ \   /\ "-./  \   /\ \/\ \   /\ "-.\ \   /\  __-.  /\  __ \      /\  ___\   /\ \       /\  __ \   /\ \/\ \   /\  __-.
\ \ \____  \ \  __ \  \ \ \-./\ \  \ \ \_\ \  \ \ \-.  \  \ \ \/\ \ \ \  __ \     \ \ \____  \ \ \____  \ \ \/\ \  \ \ \_\ \  \ \ \/\ \
 \ \_____\  \ \_\ \_\  \ \_\ \ \_\  \ \_____\  \ \_\\"\_\  \ \____-  \ \_\ \_\     \ \_____\  \ \_____\  \ \_____\  \ \_____\  \ \____-
  \/_____/   \/_/\/_/   \/_/  \/_/   \/_____/   \/_/ \/_/   \/____/   \/_/\/_/      \/_____/   \/_____/   \/_____/   \/_____/   \/____/

(ccsm-helm - 0.0.14)

### Installed Services:

- Zeebe:
  - Docker Image used for Zeebe: camunda/zeebe:1.3.4
  - Zeebe Cluster Name: "test-zeebe"
  - Prometheus ServiceMonitor Enabled: false
- Operate:
  - Enabled: true
  - Docker Image used for Operate: :1.3.4
- Tasklist:
  - Enabled: true
  - Docker Image used for Operate: :1.3.4
- Elasticsearch:
  - Enabled: true
  - ElasticSearch URL: http://elasticsearch-master:9200

### Zeebe

The Cluster itself is not exposed as a service that means that you can use `kubectl port-forward` to access the Zeebe cluster from outside Kubernetes:

> kubectl port-forward svc/test-zeebe-gateway 26500:26500 -n testbench-1-x-prod

Now you can connect your workers and clients to `localhost:26500`

### Operate

As part of the Operate HELM Chart an Ingress definition is deployed, but you require to have an Ingress Controller for that Ingress to be Exposed.
If you don't have an Ingress Controller you can do kubectl port-forward to access Operate from outside the cluster:

> kubectl port-forward svc/test-operate 8080:80

Now you can point your browser to `http://localhost:8080`

Default user and password: "demo/demo"

### Tasklist

As part of Tasklist an Ingress definition is deployed, but you require to have an Ingress Contoller for that Ingress to be Exposed.
If you don't have an Ingress Controller you can do kubectl port-forward to access tasklist from outside the cluster:

> kubectl port-forward svc/test-tasklist 8081:80

Now you can point your browser to `http://localhost:8080`

Default user and password: "demo/demo"
```

----------------------------------

When disabled:
```
NOTES:
______     ______     __    __     __  __     __   __     _____     ______        ______     __         ______     __  __     _____
/\  ___\   /\  __ \   /\ "-./  \   /\ \/\ \   /\ "-.\ \   /\  __-.  /\  __ \      /\  ___\   /\ \       /\  __ \   /\ \/\ \   /\  __-.
\ \ \____  \ \  __ \  \ \ \-./\ \  \ \ \_\ \  \ \ \-.  \  \ \ \/\ \ \ \  __ \     \ \ \____  \ \ \____  \ \ \/\ \  \ \ \_\ \  \ \ \/\ \
 \ \_____\  \ \_\ \_\  \ \_\ \ \_\  \ \_____\  \ \_\\"\_\  \ \____-  \ \_\ \_\     \ \_____\  \ \_____\  \ \_____\  \ \_____\  \ \____-
  \/_____/   \/_/\/_/   \/_/  \/_/   \/_____/   \/_/ \/_/   \/____/   \/_/\/_/      \/_____/   \/_____/   \/_____/   \/_____/   \/____/

(ccsm-helm - 0.0.14)

### Installed Services:

- Zeebe:
  - Docker Image used for Zeebe: camunda/zeebe:1.3.4
  - Zeebe Cluster Name: "test-zeebe"
  - Prometheus ServiceMonitor Enabled: false
- Operate:
  - Enabled: false
- Tasklist:
  - Enabled: false
- Elasticsearch:
  - Enabled: true
  - ElasticSearch URL: http://elasticsearch-master:9200

### Zeebe

The Cluster itself is not exposed as a service that means that you can use `kubectl port-forward` to access the Zeebe cluster from outside Kubernetes:

> kubectl port-forward svc/test-zeebe-gateway 26500:26500 -n testbench-1-x-prod

Now you can connect your workers and clients to `localhost:26500`
```