### PR TITLE
Deprecate charts

### DIFF
--- a/charts/zeebe-cluster-helm/Chart.yaml
+++ b/charts/zeebe-cluster-helm/Chart.yaml
@@ -5,6 +5,7 @@ name: zeebe-cluster-helm
 type: application
 version: 1.3.6
 icon: https://helm.camunda.io/imgs/zeebe-logo.png
+deprecated: true
 dependencies:
 - name: elasticsearch
   repository: "https://helm.elastic.co"

--- a/charts/zeebe-cluster-helm/templates/NOTES.txt
+++ b/charts/zeebe-cluster-helm/templates/NOTES.txt
@@ -28,8 +28,8 @@ Now you can connect your workers and clients to `localhost:26500`
  |_____/  |______| |_|      |_|  \_\ |______|  \_____| /_/    \_\    |_|    |______| |_____/
 
 
-Please be aware that this helm chart has been deprecated and is no longer maintained!
-It was fully replaced by new helm chart, check out helm.camunda.io for more details.
+Please note that this helm chart has been deprecated and is no longer maintained!
+Check out helm.camunda.io to find more information on how to upgrade to the new helm chart.
 
 
 

--- a/charts/zeebe-cluster-helm/templates/NOTES.txt
+++ b/charts/zeebe-cluster-helm/templates/NOTES.txt
@@ -20,4 +20,16 @@ The Cluster itself is not exposed as a service that means that you can use kubec
 Now you can connect your workers and clients to `localhost:26500`
 
 
+  _____    ______   _____    _____    ______    _____              _______   ______   _____
+ |  __ \  |  ____| |  __ \  |  __ \  |  ____|  / ____|     /\     |__   __| |  ____| |  __ \
+ | |  | | | |__    | |__) | | |__) | | |__    | |         /  \       | |    | |__    | |  | |
+ | |  | | |  __|   |  ___/  |  _  /  |  __|   | |        / /\ \      | |    |  __|   | |  | |
+ | |__| | | |____  | |      | | \ \  | |____  | |____   / ____ \     | |    | |____  | |__| |
+ |_____/  |______| |_|      |_|  \_\ |______|  \_____| /_/    \_\    |_|    |______| |_____/
+
+
+Please be aware that this helm chart has been deprecated and is no longer maintained!
+It was fully replaced by new helm chart, check out helm.camunda.io for more details.
+
+
 

--- a/charts/zeebe-full-helm/Chart.yaml
+++ b/charts/zeebe-full-helm/Chart.yaml
@@ -5,6 +5,7 @@ name: zeebe-full-helm
 version: 1.3.4
 type: application
 icon: https://helm.camunda.io/imgs/zeebe-logo.png
+deprecated: true
 dependencies:
 - name: zeebe-cluster-helm
   repository: https://camunda-community-hub.github.io/camunda-cloud-helm/

--- a/charts/zeebe-full-helm/templates/NOTES.txt
+++ b/charts/zeebe-full-helm/templates/NOTES.txt
@@ -8,6 +8,7 @@
 
 - Cluster Name: {{ tpl .Values.global.zeebe . }}
 
+
   _____    ______   _____    _____    ______    _____              _______   ______   _____
  |  __ \  |  ____| |  __ \  |  __ \  |  ____|  / ____|     /\     |__   __| |  ____| |  __ \
  | |  | | | |__    | |__) | | |__) | | |__    | |         /  \       | |    | |__    | |  | |
@@ -16,5 +17,5 @@
  |_____/  |______| |_|      |_|  \_\ |______|  \_____| /_/    \_\    |_|    |______| |_____/
 
 
-Please be aware that this helm chart has been deprecated and is no longer maintained!
-It was fully replaced by new helm chart, check out helm.camunda.io for more details.
+Please note that this helm chart has been deprecated and is no longer maintained!
+Check out helm.camunda.io to find more information on how to upgrade to the new helm chart.

--- a/charts/zeebe-full-helm/templates/NOTES.txt
+++ b/charts/zeebe-full-helm/templates/NOTES.txt
@@ -7,3 +7,14 @@
 ({{ .Chart.Name }} - {{ .Chart.Version }})
 
 - Cluster Name: {{ tpl .Values.global.zeebe . }}
+
+  _____    ______   _____    _____    ______    _____              _______   ______   _____
+ |  __ \  |  ____| |  __ \  |  __ \  |  ____|  / ____|     /\     |__   __| |  ____| |  __ \
+ | |  | | | |__    | |__) | | |__) | | |__    | |         /  \       | |    | |__    | |  | |
+ | |  | | |  __|   |  ___/  |  _  /  |  __|   | |        / /\ \      | |    |  __|   | |  | |
+ | |__| | | |____  | |      | | \ \  | |____  | |____   / ____ \     | |    | |____  | |__| |
+ |_____/  |______| |_|      |_|  \_\ |______|  \_____| /_/    \_\    |_|    |______| |_____/
+
+
+Please be aware that this helm chart has been deprecated and is no longer maintained!
+It was fully replaced by new helm chart, check out helm.camunda.io for more details.

--- a/charts/zeebe-operate-helm/Chart.yaml
+++ b/charts/zeebe-operate-helm/Chart.yaml
@@ -5,6 +5,7 @@ name: zeebe-operate-helm
 version: 1.3.3
 type: application
 icon: https://helm.camunda.io/imgs/zeebe-logo.png
+deprecated: true
 annotations:
   artifacthub.io/changes: |
     - bump operate version to 1.3.4

--- a/charts/zeebe-operate-helm/templates/NOTES.txt
+++ b/charts/zeebe-operate-helm/templates/NOTES.txt
@@ -20,6 +20,7 @@ Now you can point your browser to `http://localhost:8080`
 
 Default user and password: "demo/demo"
 
+
   _____    ______   _____    _____    ______    _____              _______   ______   _____
  |  __ \  |  ____| |  __ \  |  __ \  |  ____|  / ____|     /\     |__   __| |  ____| |  __ \
  | |  | | | |__    | |__) | | |__) | | |__    | |         /  \       | |    | |__    | |  | |
@@ -28,5 +29,5 @@ Default user and password: "demo/demo"
  |_____/  |______| |_|      |_|  \_\ |______|  \_____| /_/    \_\    |_|    |______| |_____/
 
 
-Please be aware that this helm chart has been deprecated and is no longer maintained!
-It was fully replaced by new helm chart, check out helm.camunda.io for more details.
+Please note that this helm chart has been deprecated and is no longer maintained!
+Check out helm.camunda.io to find more information on how to upgrade to the new helm chart.

--- a/charts/zeebe-operate-helm/templates/NOTES.txt
+++ b/charts/zeebe-operate-helm/templates/NOTES.txt
@@ -19,3 +19,14 @@ If you don't have an Ingress Controller you can do kubectl port-forward to acces
 Now you can point your browser to `http://localhost:8080`
 
 Default user and password: "demo/demo"
+
+  _____    ______   _____    _____    ______    _____              _______   ______   _____
+ |  __ \  |  ____| |  __ \  |  __ \  |  ____|  / ____|     /\     |__   __| |  ____| |  __ \
+ | |  | | | |__    | |__) | | |__) | | |__    | |         /  \       | |    | |__    | |  | |
+ | |  | | |  __|   |  ___/  |  _  /  |  __|   | |        / /\ \      | |    |  __|   | |  | |
+ | |__| | | |____  | |      | | \ \  | |____  | |____   / ____ \     | |    | |____  | |__| |
+ |_____/  |______| |_|      |_|  \_\ |______|  \_____| /_/    \_\    |_|    |______| |_____/
+
+
+Please be aware that this helm chart has been deprecated and is no longer maintained!
+It was fully replaced by new helm chart, check out helm.camunda.io for more details.

--- a/charts/zeebe-tasklist-helm/Chart.yaml
+++ b/charts/zeebe-tasklist-helm/Chart.yaml
@@ -4,6 +4,7 @@ description: Zeebe TaskList Helm Chart for Kubernetes
 name: zeebe-tasklist-helm
 version: 1.3.3
 icon: https://helm.camunda.io/imgs/zeebe-logo.png
+deprecated: true
 annotations:
   artifacthub.io/changes: |
     - bump tasklist version to 1.3.4

--- a/charts/zeebe-tasklist-helm/templates/NOTES.txt
+++ b/charts/zeebe-tasklist-helm/templates/NOTES.txt
@@ -18,3 +18,14 @@ If you don't have an Ingress Controller you can do kubectl port-forward to acces
 Now you can point your browser to `http://localhost:8080`
 
 Default user and password: "demo/demo"
+
+  _____    ______   _____    _____    ______    _____              _______   ______   _____
+ |  __ \  |  ____| |  __ \  |  __ \  |  ____|  / ____|     /\     |__   __| |  ____| |  __ \
+ | |  | | | |__    | |__) | | |__) | | |__    | |         /  \       | |    | |__    | |  | |
+ | |  | | |  __|   |  ___/  |  _  /  |  __|   | |        / /\ \      | |    |  __|   | |  | |
+ | |__| | | |____  | |      | | \ \  | |____  | |____   / ____ \     | |    | |____  | |__| |
+ |_____/  |______| |_|      |_|  \_\ |______|  \_____| /_/    \_\    |_|    |______| |_____/
+
+
+Please be aware that this helm chart has been deprecated and is no longer maintained!
+It was fully replaced by new helm chart, check out helm.camunda.io for more details.

--- a/charts/zeebe-tasklist-helm/templates/NOTES.txt
+++ b/charts/zeebe-tasklist-helm/templates/NOTES.txt
@@ -19,6 +19,7 @@ Now you can point your browser to `http://localhost:8080`
 
 Default user and password: "demo/demo"
 
+
   _____    ______   _____    _____    ______    _____              _______   ______   _____
  |  __ \  |  ____| |  __ \  |  __ \  |  ____|  / ____|     /\     |__   __| |  ____| |  __ \
  | |  | | | |__    | |__) | | |__) | | |__    | |         /  \       | |    | |__    | |  | |
@@ -27,5 +28,5 @@ Default user and password: "demo/demo"
  |_____/  |______| |_|      |_|  \_\ |______|  \_____| /_/    \_\    |_|    |______| |_____/
 
 
-Please be aware that this helm chart has been deprecated and is no longer maintained!
-It was fully replaced by new helm chart, check out helm.camunda.io for more details.
+Please note that this helm chart has been deprecated and is no longer maintained!
+Check out helm.camunda.io to find more information on how to upgrade to the new helm chart.


### PR DESCRIPTION
Deprecates the zeebe-* charts

Add note on:

 * zeebe-full
 * zeebe-cluster
 * zeebe-operate
 * zeebe-tasklist

Marks them depreacted in the chart.yaml