### PR TITLE
Ignore version in golden files

### DIFF
--- a/charts/ccsm-helm/test/golden/curator-configmap.golden.yaml
+++ b/charts/ccsm-helm/test/golden/curator-configmap.golden.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: ccsm-helm
-    helm.sh/chart: ccsm-helm-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.4

--- a/charts/ccsm-helm/test/golden/curator-cronjob.golden.yaml
+++ b/charts/ccsm-helm/test/golden/curator-cronjob.golden.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: ccsm-helm
-    helm.sh/chart: ccsm-helm-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.4

--- a/charts/ccsm-helm/test/golden/goldenfiles.go
+++ b/charts/ccsm-helm/test/golden/goldenfiles.go
@@ -29,7 +29,7 @@ func (s *TemplateGoldenTest) TestContainerGoldenTestDefaults() {
 		SetValues:      s.SetValues,
 	}
 	output := helm.RenderTemplate(s.T(), options, s.ChartPath, s.Release, s.Templates)
-	regex := regexp.MustCompile(".+(helm.sh/chart: ).*\n")
+	regex := regexp.MustCompile(`\s+helm.sh/chart:\s+.*`)
 	bytes := regex.ReplaceAll([]byte(output), []byte(""))
 	output = string(bytes)
 

--- a/charts/ccsm-helm/test/golden/goldenfiles.go
+++ b/charts/ccsm-helm/test/golden/goldenfiles.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"io/ioutil"
 
+	"regexp"
+
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/stretchr/testify/suite"
@@ -27,12 +29,14 @@ func (s *TemplateGoldenTest) TestContainerGoldenTestDefaults() {
 		SetValues:      s.SetValues,
 	}
 	output := helm.RenderTemplate(s.T(), options, s.ChartPath, s.Release, s.Templates)
-	actual := []byte(output)
+	regex := regexp.MustCompile(".+(helm.sh/chart: ).*\n")
+	bytes := regex.ReplaceAll([]byte(output), []byte(""))
+	output = string(bytes)
 
 	goldenFile := "golden/" + s.GoldenFileName + ".golden.yaml"
 
 	if *update {
-		err := ioutil.WriteFile(goldenFile, actual, 0644)
+		err := ioutil.WriteFile(goldenFile, bytes, 0644)
 		s.Require().NoError(err, "Golden file was not writable")
 	}
 

--- a/charts/ccsm-helm/test/golden/service-monitor.golden.yaml
+++ b/charts/ccsm-helm/test/golden/service-monitor.golden.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: ccsm-helm
-    helm.sh/chart: ccsm-helm-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.4

--- a/charts/ccsm-helm/test/operate/golden/configmap-elastic-url.golden.yaml
+++ b/charts/ccsm-helm/test/operate/golden/configmap-elastic-url.golden.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: operate
-    helm.sh/chart: operate-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1

--- a/charts/ccsm-helm/test/operate/golden/configmap.golden.yaml
+++ b/charts/ccsm-helm/test/operate/golden/configmap.golden.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: operate
-    helm.sh/chart: operate-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1

--- a/charts/ccsm-helm/test/operate/golden/deployment.golden.yaml
+++ b/charts/ccsm-helm/test/operate/golden/deployment.golden.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: operate
-    helm.sh/chart: operate-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1
@@ -20,7 +19,6 @@ spec:
     matchLabels:
       app: camunda-cloud-self-managed
       app.kubernetes.io/name: operate
-      helm.sh/chart: operate-0.0.18
       app.kubernetes.io/instance: ccsm-helm-test
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/version: 1.3.1
@@ -31,7 +29,6 @@ spec:
       labels:
         app: camunda-cloud-self-managed
         app.kubernetes.io/name: operate
-        helm.sh/chart: operate-0.0.18
         app.kubernetes.io/instance: ccsm-helm-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/version: 1.3.1

--- a/charts/ccsm-helm/test/operate/golden/ingress-all-enabled.golden.yaml
+++ b/charts/ccsm-helm/test/operate/golden/ingress-all-enabled.golden.yaml
@@ -7,7 +7,6 @@ metadata:
   labels: 
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: operate
-    helm.sh/chart: operate-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1

--- a/charts/ccsm-helm/test/operate/golden/ingress.golden.yaml
+++ b/charts/ccsm-helm/test/operate/golden/ingress.golden.yaml
@@ -7,7 +7,6 @@ metadata:
   labels: 
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: operate
-    helm.sh/chart: operate-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1

--- a/charts/ccsm-helm/test/operate/golden/service.golden.yaml
+++ b/charts/ccsm-helm/test/operate/golden/service.golden.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: operate
-    helm.sh/chart: operate-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1
@@ -23,7 +22,6 @@ spec:
   selector:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: operate
-    helm.sh/chart: operate-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1

--- a/charts/ccsm-helm/test/operate/golden/serviceaccount.golden.yaml
+++ b/charts/ccsm-helm/test/operate/golden/serviceaccount.golden.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: operate
-    helm.sh/chart: operate-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1

--- a/charts/ccsm-helm/test/tasklist/golden/configmap.golden.yaml
+++ b/charts/ccsm-helm/test/tasklist/golden/configmap.golden.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: tasklist
-    helm.sh/chart: tasklist-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1

--- a/charts/ccsm-helm/test/tasklist/golden/deployment.golden.yaml
+++ b/charts/ccsm-helm/test/tasklist/golden/deployment.golden.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: tasklist
-    helm.sh/chart: tasklist-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1
@@ -19,7 +18,6 @@ spec:
     matchLabels:
       app: camunda-cloud-self-managed
       app.kubernetes.io/name: tasklist
-      helm.sh/chart: tasklist-0.0.18
       app.kubernetes.io/instance: ccsm-helm-test
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/version: 1.3.1
@@ -30,7 +28,6 @@ spec:
       labels:
         app: camunda-cloud-self-managed
         app.kubernetes.io/name: tasklist
-        helm.sh/chart: tasklist-0.0.18
         app.kubernetes.io/instance: ccsm-helm-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/version: 1.3.1

--- a/charts/ccsm-helm/test/tasklist/golden/service.golden.yaml
+++ b/charts/ccsm-helm/test/tasklist/golden/service.golden.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: tasklist
-    helm.sh/chart: tasklist-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1
@@ -23,7 +22,6 @@ spec:
   selector:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: tasklist
-    helm.sh/chart: tasklist-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1

--- a/charts/ccsm-helm/test/zeebe-gateway/golden/configmap.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe-gateway/golden/configmap.golden.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: zeebe-gateway
-    helm.sh/chart: zeebe-gateway-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1

--- a/charts/ccsm-helm/test/zeebe-gateway/golden/gateway-deployment.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe-gateway/golden/gateway-deployment.golden.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: zeebe-gateway
-    helm.sh/chart: zeebe-gateway-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1
@@ -20,7 +19,6 @@ spec:
     matchLabels:
       app: camunda-cloud-self-managed
       app.kubernetes.io/name: zeebe-gateway
-      helm.sh/chart: zeebe-gateway-0.0.18
       app.kubernetes.io/instance: ccsm-helm-test
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/version: 1.3.1
@@ -31,7 +29,6 @@ spec:
       labels:
         app: camunda-cloud-self-managed
         app.kubernetes.io/name: zeebe-gateway
-        helm.sh/chart: zeebe-gateway-0.0.18
         app.kubernetes.io/instance: ccsm-helm-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/version: 1.3.1

--- a/charts/ccsm-helm/test/zeebe-gateway/golden/gateway-service.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe-gateway/golden/gateway-service.golden.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: zeebe-gateway
-    helm.sh/chart: zeebe-gateway-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1
@@ -20,7 +19,6 @@ spec:
   selector:
       app: camunda-cloud-self-managed
       app.kubernetes.io/name: zeebe-gateway
-      helm.sh/chart: zeebe-gateway-0.0.18
       app.kubernetes.io/instance: ccsm-helm-test
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/version: 1.3.1

--- a/charts/ccsm-helm/test/zeebe-gateway/golden/gateway-serviceaccount.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe-gateway/golden/gateway-serviceaccount.golden.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: zeebe-gateway
-    helm.sh/chart: zeebe-gateway-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1

--- a/charts/ccsm-helm/test/zeebe-gateway/golden/poddisruptionbudget.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe-gateway/golden/poddisruptionbudget.golden.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: zeebe-gateway
-    helm.sh/chart: zeebe-gateway-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1
@@ -19,7 +18,6 @@ spec:
     matchLabels:
       app: camunda-cloud-self-managed
       app.kubernetes.io/name: zeebe-gateway
-      helm.sh/chart: zeebe-gateway-0.0.18
       app.kubernetes.io/instance: ccsm-helm-test
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/version: 1.3.1

--- a/charts/ccsm-helm/test/zeebe/golden/configmap-log4j2.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe/golden/configmap-log4j2.golden.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: zeebe
-    helm.sh/chart: zeebe-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1

--- a/charts/ccsm-helm/test/zeebe/golden/configmap.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe/golden/configmap.golden.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: zeebe
-    helm.sh/chart: zeebe-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1

--- a/charts/ccsm-helm/test/zeebe/golden/poddisruptionbudget.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe/golden/poddisruptionbudget.golden.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: zeebe
-    helm.sh/chart: zeebe-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1
@@ -19,7 +18,6 @@ spec:
     matchLabels:
       app: camunda-cloud-self-managed
       app.kubernetes.io/name: zeebe
-      helm.sh/chart: zeebe-0.0.18
       app.kubernetes.io/instance: ccsm-helm-test
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/version: 1.3.1

--- a/charts/ccsm-helm/test/zeebe/golden/service.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe/golden/service.golden.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: zeebe
-    helm.sh/chart: zeebe-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1
@@ -32,7 +31,6 @@ spec:
   selector:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: zeebe
-    helm.sh/chart: zeebe-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1

--- a/charts/ccsm-helm/test/zeebe/golden/serviceaccount.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe/golden/serviceaccount.golden.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: zeebe
-    helm.sh/chart: zeebe-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1

--- a/charts/ccsm-helm/test/zeebe/golden/statefulset-containersecuritycontext.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe/golden/statefulset-containersecuritycontext.golden.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: zeebe
-    helm.sh/chart: zeebe-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1
@@ -20,7 +19,6 @@ spec:
     matchLabels:
       app: camunda-cloud-self-managed
       app.kubernetes.io/name: zeebe
-      helm.sh/chart: zeebe-0.0.18
       app.kubernetes.io/instance: ccsm-helm-test
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/version: 1.3.1
@@ -35,7 +33,6 @@ spec:
       labels:
         app: camunda-cloud-self-managed
         app.kubernetes.io/name: zeebe
-        helm.sh/chart: zeebe-0.0.18
         app.kubernetes.io/instance: ccsm-helm-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/version: 1.3.1

--- a/charts/ccsm-helm/test/zeebe/golden/statefulset.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe/golden/statefulset.golden.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: camunda-cloud-self-managed
     app.kubernetes.io/name: zeebe
-    helm.sh/chart: zeebe-0.0.18
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/version: 1.3.1
@@ -20,7 +19,6 @@ spec:
     matchLabels:
       app: camunda-cloud-self-managed
       app.kubernetes.io/name: zeebe
-      helm.sh/chart: zeebe-0.0.18
       app.kubernetes.io/instance: ccsm-helm-test
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/version: 1.3.1
@@ -35,7 +33,6 @@ spec:
       labels:
         app: camunda-cloud-self-managed
         app.kubernetes.io/name: zeebe
-        helm.sh/chart: zeebe-0.0.18
         app.kubernetes.io/instance: ccsm-helm-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/version: 1.3.1


### PR DESCRIPTION
The chart version does change regularly, we should ignore them on golden files to not always need to re-generate them.


Related https://medium.com/@jarifibrahim/golden-files-why-you-should-use-them-47087ec994bf